### PR TITLE
[PRA-147] Adding istio annotation for notebook executors

### DIFF
--- a/src/managers/manifests.py
+++ b/src/managers/manifests.py
@@ -214,6 +214,10 @@ class KubernetesManifestsManager(ManagerStatusProtocol, WithLogging):
                 f"spark.driver.port={SPARK_DRIVER_PORT}",
                 "--conf",
                 f"spark.blockManager.port={SPARK_BLOCK_MANAGER_PORT}",
+                "--conf",
+                f"spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeInboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
+                "--conf",
+                f"spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeOutboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
             ],
             annotations={
                 "traffic.sidecar.istio.io/excludeInboundPorts": f"{SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",

--- a/tests/integration/test_spark.py
+++ b/tests/integration/test_spark.py
@@ -351,6 +351,10 @@ def test_pod_default_gets_applied(
                     f"spark.driver.port={SPARK_DRIVER_PORT}",
                     "--conf",
                     f"spark.blockManager.port={SPARK_BLOCK_MANAGER_PORT}",
+                    "--conf",
+                    f"spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeInboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
+                    "--conf",
+                    f"spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeOutboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
                 ]
                 annotations = notebook_pod.metadata.annotations
                 assert (


### PR DESCRIPTION
This feature is required in order to ensure that also executors have istio annotations that would allow executors<>executors communication