### PR TITLE
[PRA-161] Refactor code to follow code pattern

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -11,6 +11,13 @@ from data_platform_helpers.advanced_statuses.handler import StatusHandler
 
 from core.state import GlobalState
 from events.general import GeneralEventsHandler
+from events.kafka import KafkaEventsHandler
+from events.manifest import ManifestEventsHandler
+from events.mongodb import MongoDBEventsHandler
+from events.mysql import MySQLEventsHandler
+from events.opensearch import OpenSearchEventsHandler
+from events.postgres import PostgresEventsHandler
+from events.spark import SparkEventsHandler
 from managers.kafka import KafkaManager
 from managers.manifests import KubernetesManifestsManager
 from managers.mongodb import MongodbManager
@@ -18,6 +25,7 @@ from managers.mysql import MysqlManager
 from managers.opensearch import OpenSearchManager
 from managers.postgresql import PostgresqlManager
 from managers.spark import SparkManager
+from managers.database import DatabaseManager
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +61,13 @@ class KubeflowIntegratorCharm(ops.CharmBase):
 
         # Event Handlers
         self.general_events = GeneralEventsHandler(self, self.state)
+        self.kafka_events = KafkaEventsHandler(self, self.state)
+        self.mongodb_events = MongoDBEventsHandler(self, self.state)
+        self.mysql_events = MySQLEventsHandler(self, self.state)
+        self.opensearch_events = OpenSearchEventsHandler(self, self.state)
+        self.postgres_events = PostgresEventsHandler(self, self.state)
+        self.spark_events = SparkEventsHandler(self, self.state)
+        self.manifest_events = ManifestEventsHandler(self, self.state)
 
 
 if __name__ == "__main__":  # pragma: nocover

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,7 +16,7 @@ from events.manifest import ManifestEventsHandler
 from events.mongodb import MongoDBEventsHandler
 from events.mysql import MySQLEventsHandler
 from events.opensearch import OpenSearchEventsHandler
-from events.postgres import PostgresEventsHandler
+from events.postgresql import PostgresqlEventsHandler
 from events.spark import SparkEventsHandler
 from managers.kafka import KafkaManager
 from managers.mongodb import MongodbManager
@@ -64,7 +64,7 @@ class KubeflowIntegratorCharm(ops.CharmBase):
         self.mongodb_events = MongoDBEventsHandler(self, self.state)
         self.mysql_events = MySQLEventsHandler(self, self.state)
         self.opensearch_events = OpenSearchEventsHandler(self, self.state)
-        self.postgres_events = PostgresEventsHandler(self, self.state)
+        self.postgresql_events = PostgresqlEventsHandler(self, self.state)
         self.spark_events = SparkEventsHandler(self, self.state)
         self.manifest_events = ManifestEventsHandler(self, self.state)
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,13 +19,12 @@ from events.opensearch import OpenSearchEventsHandler
 from events.postgres import PostgresEventsHandler
 from events.spark import SparkEventsHandler
 from managers.kafka import KafkaManager
-from managers.manifests import KubernetesManifestsManager
 from managers.mongodb import MongodbManager
 from managers.mysql import MysqlManager
 from managers.opensearch import OpenSearchManager
 from managers.postgresql import PostgresqlManager
+from managers.profile import KubeflowProfileManager
 from managers.spark import SparkManager
-from managers.database import DatabaseManager
 
 logger = logging.getLogger(__name__)
 
@@ -46,11 +45,11 @@ class KubeflowIntegratorCharm(ops.CharmBase):
         self.postgresql_manager = PostgresqlManager(self.state)
         self.mongodb_manager = MongodbManager(self.state)
         self.spark_manager = SparkManager(self.state)
-        self.manifests_manager = KubernetesManifestsManager(self.state)
+        self.profile_manager = KubeflowProfileManager(self.state)
 
         self.status = StatusHandler(  # priority order
             self,
-            self.manifests_manager,
+            self.profile_manager,
             self.kafka_manager,
             self.opensearch_manager,
             self.mysql_manager,

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -242,7 +242,7 @@ class GlobalState(Object, WithLogging, StatusesStateProtocol):
         return self.is_relation_ready(self.kafka_requirer)
 
     def is_spark_related(self) -> bool:
-        """Check if we have a relation with Kafka."""
+        """Check if we have a relation with Integration Hub."""
         return self.is_relation_ready(
             self.spark_requirer, ["service-account", "resource-manifest", "spark-properties"]
         )

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -13,13 +13,14 @@ from charms.data_platform_libs.v0.data_interfaces import (
     DataPeerUnitData,
     KafkaRequirerData,
     OpenSearchRequiresData,
+    RequirerData,
 )
 from charms.data_platform_libs.v0.data_models import ValidationError
 from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountRequirerData,
 )
 from data_platform_helpers.advanced_statuses.protocol import StatusesState, StatusesStateProtocol
-from ops import Object, Relation
+from ops import Object
 
 from constants import (
     KAFKA_RELATION_NAME,
@@ -108,30 +109,6 @@ class GlobalState(Object, WithLogging, StatusesStateProtocol):
 
         self.statuses = StatusesState(self, STATUS_PEERS_RELATION_NAME)
 
-    # Relations
-
-    @property
-    def peer_relation(self) -> Relation | None:
-        """Get the cluster peer relation."""
-        return self.model.get_relation(PEER_RELATION)
-
-    @property
-    def opensearch_relation(self) -> Relation | None:
-        """Get the opensearch relation."""
-        return self.model.get_relation(OPENSEARCH_RELATION_NAME)
-
-    @property
-    def postgresql_relation(self) -> Relation | None:
-        """Get the postgresql relation."""
-        return self.model.get_relation(POSTGRESQL_RLEATION_NAME)
-
-    @property
-    def mysql_relation(self) -> Relation | None:
-        """Get the mysql relation."""
-        return self.model.get_relation(MYSQL_RELATION_NAME)
-
-    # Charm Configurations
-
     @property
     def opensearch_config(self) -> OpenSearchConfig | None:
         """Return information regarding opensearch config options."""
@@ -188,149 +165,87 @@ class GlobalState(Object, WithLogging, StatusesStateProtocol):
         except ValidationError:
             return None
 
-    # OpenSearch Relation
+    def _get_field(self, relation_data: RequirerData, field: str) -> str | None:
+        """Get a field from the first relation if it exists."""
+        if relation := relation_data.relations[0] if len(relation_data.relations) else None:
+            return relation_data.fetch_relation_field(relation.id, field)
+        return None
+
+    def is_relation_ready(
+        self, relation_data: RequirerData, required_fields: list[str] | None = None
+    ) -> bool:
+        """Check if we have a relation with a database."""
+        required_fields = required_fields or ["username", "password"]
+        for relation in relation_data.relations:
+            data = relation_data.fetch_relation_data([relation.id], required_fields).get(
+                relation.id, {}
+            )
+            if all(data.get(key) for key in required_fields):
+                return True
+        return False
+
     @property
     def active_opensearch_index(self) -> str | None:
         """Return the created and configured opensearch index."""
-        if (
-            relation := self.opensearch_requirer.relations[0]
-            if len(self.opensearch_requirer.relations)
-            else None
-        ):
-            return self.opensearch_requirer.fetch_relation_field(relation.id, "index")
-        return None
+        return self._get_field(self.opensearch_requirer, "index")
 
-    def is_opensearch_related(self) -> bool:
-        """Check if we have a relation with OpenSearch."""
-        for relation in self.opensearch_requirer.relations:
-            data = self.opensearch_requirer.fetch_relation_data(
-                [relation.id], ["username", "password"]
-            ).get(relation.id, {})
-            if all(data.get(key) for key in ("username", "password")):
-                return True
-        return False
-
-    # PostgreSQL Relation
     @property
     def active_postgresql_database(self) -> str | None:
         """Return the created and configured postgresql database."""
-        if (
-            relation := self.postgresql_requirer.relations[0]
-            if len(self.postgresql_requirer.relations)
-            else None
-        ):
-            return self.postgresql_requirer.fetch_relation_field(relation.id, "database")
-        return None
+        return self._get_field(self.postgresql_requirer, "database")
 
-    def is_postgresql_related(self) -> bool:
-        """Check if we have a relation with PostgreSQL."""
-        for relation in self.postgresql_requirer.relations:
-            data = self.postgresql_requirer.fetch_relation_data(
-                [relation.id], ["username", "password"]
-            ).get(relation.id, {})
-            if all(data.get(key) for key in ("username", "password")):
-                return True
-        return False
-
-    # MySQL Relation
     @property
     def active_mysql_database(self) -> str | None:
         """Return the created and configured mysql database."""
-        if (
-            relation := self.mysql_requirer.relations[0]
-            if len(self.mysql_requirer.relations)
-            else None
-        ):
-            return self.mysql_requirer.fetch_relation_field(relation.id, "database")
-        return None
+        return self._get_field(self.mysql_requirer, "database")
 
-    def is_mysql_related(self) -> bool:
-        """Check if we have a relation with MySQL."""
-        for relation in self.mysql_requirer.relations:
-            data = self.mysql_requirer.fetch_relation_data(
-                [relation.id], ["username", "password"]
-            ).get(relation.id, {})
-            if all(data.get(key) for key in ("username", "password")):
-                return True
-        return False
-
-    # MongoDB Relation
     @property
     def active_mongodb_database(self) -> str | None:
         """Return the created and configured mongodb database."""
-        if (
-            relation := self.mongodb_requirer.relations[0]
-            if len(self.mongodb_requirer.relations)
-            else None
-        ):
-            return self.mongodb_requirer.fetch_relation_field(relation.id, "database")
-        return None
+        return self._get_field(self.mongodb_requirer, "database")
 
-    def is_mongodb_related(self) -> bool:
-        """Check if we have a relation with MongoDB."""
-        for relation in self.mongodb_requirer.relations:
-            data = self.mongodb_requirer.fetch_relation_data(
-                [relation.id], ["username", "password"]
-            ).get(relation.id, {})
-            if all(data.get(key) for key in ("username", "password")):
-                return True
-        return False
-
-    # Kafka Relation
     @property
     def active_kafka_topic(self) -> str | None:
         """Return the created and configured kafka topic."""
-        if (
-            relation := self.kafka_requirer.relations[0]
-            if len(self.kafka_requirer.relations)
-            else None
-        ):
-            return self.kafka_requirer.fetch_relation_field(relation.id, "topic")
-        return None
-
-    def is_kafka_related(self) -> bool:
-        """Check if we have a relation with Kafka."""
-        for relation in self.kafka_requirer.relations:
-            data = self.kafka_requirer.fetch_relation_data(
-                [relation.id], ["username", "password"]
-            ).get(relation.id, {})
-            if all(data.get(key) for key in ("username", "password")):
-                return True
-        return False
-
-    # Spark Relation
-    def is_spark_related(self) -> bool:
-        """Check if we have a relation with Kafka."""
-        for relation in self.spark_requirer.relations:
-            data = self.spark_requirer.fetch_relation_data(
-                [relation.id], ["service-account", "resource-manifest", "spark-properties"]
-            ).get(relation.id, {})
-            if all(
-                data.get(key)
-                for key in ("service-account", "resource-manifest", "spark-properties")
-            ):
-                return True
-        return False
+        return self._get_field(self.kafka_requirer, "topic")
 
     @property
     def active_spark_service_account(self) -> str | None:
         """Return the service account that was created and configured."""
-        if (
-            relation := self.spark_requirer.relations[0]
-            if len(self.spark_requirer.relations)
-            else None
-        ):
-            sa_with_namespace = self.spark_requirer.fetch_relation_field(
-                relation.id, "service-account"
-            )
-            if not sa_with_namespace:
-                return None
-            parts = sa_with_namespace.split(":")
-            if len(parts) != 2:
-                return None
-            _, service_account = parts
-            return service_account
-        return None
+        sa_with_namespace = self._get_field(self.spark_requirer, "service-account")
+        if not sa_with_namespace:
+            return None
+        parts = sa_with_namespace.split(":")
+        if len(parts) != 2:
+            return None
+        _, service_account = parts
+        return service_account
+
+    def is_opensearch_related(self) -> bool:
+        """Check if we have a relation with OpenSearch."""
+        return self.is_relation_ready(self.opensearch_requirer)
+
+    def is_postgresql_related(self) -> bool:
+        """Check if we have a relation with PostgreSQL."""
+        return self.is_relation_ready(self.postgresql_requirer)
+
+    def is_mysql_related(self) -> bool:
+        """Check if we have a relation with MySQL."""
+        return self.is_relation_ready(self.mysql_requirer)
+
+    def is_mongodb_related(self) -> bool:
+        """Check if we have a relation with MongoDB."""
+        return self.is_relation_ready(self.mongodb_requirer)
+
+    def is_kafka_related(self) -> bool:
+        """Check if we have a relation with Kafka."""
+        return self.is_relation_ready(self.kafka_requirer)
+
+    def is_spark_related(self) -> bool:
+        """Check if we have a relation with Kafka."""
+        return self.is_relation_ready(
+            self.spark_requirer, ["service-account", "resource-manifest", "spark-properties"]
+        )
 
     def is_k8s_secrets_manifests_related(self) -> bool:
         """Is the charm related to a secrets manifests relation."""

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -7,18 +7,38 @@
 
 from typing import TYPE_CHECKING
 
+from jinja2 import Template
+
 from charms.data_platform_libs.v0.data_interfaces import (
     DataPeerData,
     DataPeerUnitData,
+    OpenSearchRequiresData,
+    DatabaseRequirerData,
+    KafkaRequirerData,
+)
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
+    SparkServiceAccountRequirerData,
 )
 from charms.data_platform_libs.v0.data_models import ValidationError
 from data_platform_helpers.advanced_statuses.protocol import StatusesState, StatusesStateProtocol
 from ops import Object, Relation
 
 from constants import (
+    KAFKA_RELATION_NAME,
+    MONGODB_RELATION_NAME,
+    MYSQL_RELATION_NAME,
+    OPENSEARCH_RELATION_NAME,
     PEER_RELATION,
+    POSTGRESQL_RLEATION_NAME,
+    SPARK_RELATION_NAME,
     STATUS_PEERS_RELATION_NAME,
+    POD_DEFAULTS_DISPATCHER_RELATION_NAME,
+    ROLEBINDINGS_DISPATCHER_RELATION_NAME,
+    ROLES_DISPATCHER_RELATION_NAME,
+    SECRETS_DISPATCHER_RELATION_NAME,
+    SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME,
 )
+
 from core.config import (
     KafkaConfig,
     MongoDbConfig,
@@ -41,17 +61,79 @@ class GlobalState(Object, WithLogging, StatusesStateProtocol):
         super().__init__(charm, "charm_state")
         self.charm = charm
         self.config = charm.config
+
         self.peer_app_interface = DataPeerData(
             self.model,
             relation_name=PEER_RELATION,
         )
         self.peer_unit_interface = DataPeerUnitData(self.model, relation_name=PEER_RELATION)
+        self.opensearch_requirer = OpenSearchRequiresData(
+            self.charm.model,
+            OPENSEARCH_RELATION_NAME,
+            getattr(self.opensearch_config, "index_name", ""),
+            extra_user_roles=getattr(self.opensearch_config, "extra_user_roles", ""),
+        )
+        self.postgresql_requirer = DatabaseRequirerData(
+            self.charm.model,
+            relation_name=POSTGRESQL_RLEATION_NAME,
+            database_name=getattr(self.postgresql_config, "database_name", ""),
+            extra_user_roles=getattr(self.postgresql_config, "extra_user_roles", ""),
+        )
+        self.mysql_requirer = DatabaseRequirerData(
+            self.charm.model,
+            relation_name=MYSQL_RELATION_NAME,
+            database_name=getattr(self.mysql_config, "database_name", ""),
+            extra_user_roles=getattr(self.mysql_config, "extra_user_roles", ""),
+        )
+        self.mongodb_requirer = DatabaseRequirerData(
+            self.charm.model,
+            relation_name=MONGODB_RELATION_NAME,
+            database_name=getattr(self.mongodb_config, "database_name", ""),
+            extra_user_roles=getattr(self.mongodb_config, "extra_user_roles", ""),
+        )
+        self.kafka_requirer = KafkaRequirerData(
+            self.charm.model,
+            relation_name=KAFKA_RELATION_NAME,
+            topic=getattr(self.state.kafka_config, "topic_name", ""),
+            extra_user_roles=getattr(self.state.kafka_config, "extra_user_roles", ""),
+            consumer_group_prefix=getattr(self.state.kafka_config, "consumer_group_prefix", ""),
+        )
+
+        profile = getattr(self.state.profile_config, "profile", "")
+        namespace = profile if profile != "*" else self.charm.model.name
+        username = getattr(self.state.spark_config, "spark_service_account", "")
+        self.spark_requirer = SparkServiceAccountRequirerData(
+            self.charm,
+            relation_name=SPARK_RELATION_NAME,
+            service_account=f"{namespace}:{username}",
+            skip_creation=True,
+        )
+
         self.statuses = StatusesState(self, STATUS_PEERS_RELATION_NAME)
+
+    # Relations
 
     @property
     def peer_relation(self) -> Relation | None:
         """Get the cluster peer relation."""
         return self.model.get_relation(PEER_RELATION)
+
+    @property
+    def opensearch_relation(self) -> Relation | None:
+        """Get the opensearch relation."""
+        return self.model.get_relation(OPENSEARCH_RELATION_NAME)
+
+    @property
+    def postgresql_relation(self) -> Relation | None:
+        """Get the postgresql relation."""
+        return self.model.get_relation(POSTGRESQL_RLEATION_NAME)
+
+    @property
+    def mysql_relation(self) -> Relation | None:
+        """Get the mysql relation."""
+        return self.model.get_relation(MYSQL_RELATION_NAME)
+
+    # Charm Configurations
 
     @property
     def opensearch_config(self) -> OpenSearchConfig | None:
@@ -105,8 +187,184 @@ class GlobalState(Object, WithLogging, StatusesStateProtocol):
     def profile_config(self) -> ProfileConfig | None:
         """Return information regarding the profile config option."""
         try:
-            validated_config = ProfileConfig(**self.config)
+            return ProfileConfig(**self.config)
         except ValidationError:
             return None
 
-        return validated_config
+    # OpenSearch Relation
+    @property
+    def active_opensearch_index(self) -> str | None:
+        """Return the created and configured opensearch index."""
+        if (
+            relation := self.opensearch_requirer.relations[0]
+            if len(self.opensearch_requirer.relations)
+            else None
+        ):
+            return self.opensearch_requirer.fetch_relation_field(relation.id, "index")
+        return None
+
+    def is_opensearch_related(self) -> bool:
+        """Check if we have a relation with OpenSearch."""
+        for relation in self.opensearch_requirer.relations:
+            data = self.opensearch_requirer.fetch_relation_data(
+                [relation.id], ["username", "password"]
+            ).get(relation.id, {})
+            if all(data.get(key) for key in ("username", "password")):
+                return True
+        return False
+
+    # PostgreSQL Relation
+    @property
+    def active_postgresql_database(self) -> str | None:
+        """Return the created and configured postgresql database."""
+        if (
+            relation := self.postgresql_requirer.relations[0]
+            if len(self.postgresql_requirer.relations)
+            else None
+        ):
+            return self.postgresql_requirer.fetch_relation_field(relation.id, "database")
+        return None
+
+    def is_postgresql_related(self) -> bool:
+        """Check if we have a relation with PostgreSQL."""
+        for relation in self.postgresql_requirer.relations:
+            data = self.postgresql_requirer.fetch_relation_data(
+                [relation.id], ["username", "password"]
+            ).get(relation.id, {})
+            if all(data.get(key) for key in ("username", "password")):
+                return True
+        return False
+
+    # MySQL Relation
+    @property
+    def active_mysql_database(self) -> str | None:
+        """Return the created and configured mysql database."""
+        if (
+            relation := self.mysql_requirer.relations[0]
+            if len(self.mysql_requirer.relations)
+            else None
+        ):
+            return self.mysql_requirer.fetch_relation_field(relation.id, "database")
+        return None
+
+    def is_mysql_related(self) -> bool:
+        """Check if we have a relation with MySQL."""
+        for relation in self.mysql_requirer.relations:
+            data = self.mysql_requirer.fetch_relation_data(
+                [relation.id], ["username", "password"]
+            ).get(relation.id, {})
+            if all(data.get(key) for key in ("username", "password")):
+                return True
+        return False
+
+    # MongoDB Relation
+    @property
+    def active_mongodb_database(self) -> str | None:
+        """Return the created and configured mongodb database."""
+        if (
+            relation := self.mongodb_requirer.relations[0]
+            if len(self.mongodb_requirer.relations)
+            else None
+        ):
+            return self.mongodb_requirer.fetch_relation_field(relation.id, "database")
+        return None
+
+    def is_mongodb_related(self) -> bool:
+        """Check if we have a relation with MongoDB."""
+        for relation in self.mongodb_requirer.relations:
+            data = self.mongodb_requirer.fetch_relation_data(
+                [relation.id], ["username", "password"]
+            ).get(relation.id, {})
+            if all(data.get(key) for key in ("username", "password")):
+                return True
+        return False
+
+    # Kafka Relation
+    @property
+    def active_kafka_topic(self) -> str | None:
+        """Return the created and configured kafka topic."""
+        if (
+            relation := self.kafka_requirer.relations[0]
+            if len(self.kafka_requirer.relations)
+            else None
+        ):
+            return self.kafka_requirer.fetch_relation_field(relation.id, "topic")
+        return None
+
+    def is_kafka_related(self) -> bool:
+        """Check if we have a relation with Kafka."""
+        for relation in self.kafka_requirer.relations:
+            data = self.kafka_requirer.fetch_relation_data(
+                [relation.id], ["username", "password"]
+            ).get(relation.id, {})
+            if all(data.get(key) for key in ("username", "password")):
+                return True
+        return False
+
+    # Spark Relation
+    def is_spark_related(self) -> bool:
+        """Check if we have a relation with Kafka."""
+        for relation in self.spark_requirer.relations:
+            data = self.spark_requirer.fetch_relation_data(
+                [relation.id], ["service-account", "resource-manifest", "spark-properties"]
+            ).get(relation.id, {})
+            if all(
+                data.get(key)
+                for key in ("service-account", "resource-manifest", "spark-properties")
+            ):
+                return True
+        return False
+
+    @property
+    def active_spark_service_account(self) -> str | None:
+        """Return the service account that was created and configured."""
+        if (
+            relation := self.spark_requirer.relations[0]
+            if len(self.spark_requirer.relations)
+            else None
+        ):
+            sa_with_namespace = self.spark_requirer.fetch_relation_field(
+                relation.id, "service-account"
+            )
+            if not sa_with_namespace:
+                return None
+            parts = sa_with_namespace.split(":")
+            if len(parts) != 2:
+                return None
+            _, service_account = parts
+            return service_account
+        return None
+
+    def is_k8s_secrets_manifests_related(self) -> bool:
+        """Is the charm related to a secrets manifests relation."""
+        return bool(self.state.charm.model.relations.get(SECRETS_DISPATCHER_RELATION_NAME))
+
+    def is_k8s_poddefaults_manifests_related(self) -> bool:
+        """Is the charm related to a poddefaults manifests relation."""
+        return bool(self.state.charm.model.relations.get(POD_DEFAULTS_DISPATCHER_RELATION_NAME))
+
+    def is_k8s_service_accounts_manifests_related(self) -> bool:
+        """Is the charm related to a serviceaccounts manifests relation."""
+        return bool(
+            self.state.charm.model.relations.get(SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME)
+        )
+
+    def is_k8s_roles_manifests_related(self) -> bool:
+        """Is the charm related to a roles manifests relation."""
+        return bool(self.state.charm.model.relations.get(ROLES_DISPATCHER_RELATION_NAME))
+
+    def is_k8s_rolebindings_manifests_related(self) -> bool:
+        """Is the charm related to a rolebindings manifests relation."""
+        return bool(self.state.charm.model.relations.get(ROLEBINDINGS_DISPATCHER_RELATION_NAME))
+
+    def is_manifests_provider_related(self):
+        """Is the charm related to any manifests relation provider."""
+        return any(
+            [
+                self.is_k8s_poddefaults_manifests_related,
+                self.is_k8s_secrets_manifests_related,
+                self.is_k8s_service_accounts_manifests_related,
+                self.is_k8s_roles_manifests_related,
+                self.is_k8s_rolebindings_manifests_related,
+            ]
+        )

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -174,7 +174,7 @@ class GlobalState(Object, WithLogging, StatusesStateProtocol):
     def is_relation_ready(
         self, relation_data: RequirerData, required_fields: list[str] | None = None
     ) -> bool:
-        """Check if we have a relation with a database."""
+        """Check if we have a relation with the desired product."""
         required_fields = required_fields or ["username", "password"]
         for relation in relation_data.relations:
             data = relation_data.fetch_relation_data([relation.id], required_fields).get(

--- a/src/core/state.py
+++ b/src/core/state.py
@@ -7,19 +7,17 @@
 
 from typing import TYPE_CHECKING
 
-from jinja2 import Template
-
 from charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseRequirerData,
     DataPeerData,
     DataPeerUnitData,
-    OpenSearchRequiresData,
-    DatabaseRequirerData,
     KafkaRequirerData,
+    OpenSearchRequiresData,
 )
+from charms.data_platform_libs.v0.data_models import ValidationError
 from charms.spark_integration_hub_k8s.v0.spark_service_account import (
     SparkServiceAccountRequirerData,
 )
-from charms.data_platform_libs.v0.data_models import ValidationError
 from data_platform_helpers.advanced_statuses.protocol import StatusesState, StatusesStateProtocol
 from ops import Object, Relation
 
@@ -29,16 +27,15 @@ from constants import (
     MYSQL_RELATION_NAME,
     OPENSEARCH_RELATION_NAME,
     PEER_RELATION,
-    POSTGRESQL_RLEATION_NAME,
-    SPARK_RELATION_NAME,
-    STATUS_PEERS_RELATION_NAME,
     POD_DEFAULTS_DISPATCHER_RELATION_NAME,
+    POSTGRESQL_RLEATION_NAME,
     ROLEBINDINGS_DISPATCHER_RELATION_NAME,
     ROLES_DISPATCHER_RELATION_NAME,
     SECRETS_DISPATCHER_RELATION_NAME,
     SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME,
+    SPARK_RELATION_NAME,
+    STATUS_PEERS_RELATION_NAME,
 )
-
 from core.config import (
     KafkaConfig,
     MongoDbConfig,
@@ -94,16 +91,16 @@ class GlobalState(Object, WithLogging, StatusesStateProtocol):
         self.kafka_requirer = KafkaRequirerData(
             self.charm.model,
             relation_name=KAFKA_RELATION_NAME,
-            topic=getattr(self.state.kafka_config, "topic_name", ""),
-            extra_user_roles=getattr(self.state.kafka_config, "extra_user_roles", ""),
-            consumer_group_prefix=getattr(self.state.kafka_config, "consumer_group_prefix", ""),
+            topic=getattr(self.kafka_config, "topic_name", ""),
+            extra_user_roles=getattr(self.kafka_config, "extra_user_roles", ""),
+            consumer_group_prefix=getattr(self.kafka_config, "consumer_group_prefix", ""),
         )
 
-        profile = getattr(self.state.profile_config, "profile", "")
+        profile = getattr(self.profile_config, "profile", "")
         namespace = profile if profile != "*" else self.charm.model.name
-        username = getattr(self.state.spark_config, "spark_service_account", "")
+        username = getattr(self.spark_config, "spark_service_account", "")
         self.spark_requirer = SparkServiceAccountRequirerData(
-            self.charm,
+            self.charm.model,
             relation_name=SPARK_RELATION_NAME,
             service_account=f"{namespace}:{username}",
             skip_creation=True,
@@ -337,34 +334,32 @@ class GlobalState(Object, WithLogging, StatusesStateProtocol):
 
     def is_k8s_secrets_manifests_related(self) -> bool:
         """Is the charm related to a secrets manifests relation."""
-        return bool(self.state.charm.model.relations.get(SECRETS_DISPATCHER_RELATION_NAME))
+        return bool(self.charm.model.relations.get(SECRETS_DISPATCHER_RELATION_NAME))
 
     def is_k8s_poddefaults_manifests_related(self) -> bool:
         """Is the charm related to a poddefaults manifests relation."""
-        return bool(self.state.charm.model.relations.get(POD_DEFAULTS_DISPATCHER_RELATION_NAME))
+        return bool(self.charm.model.relations.get(POD_DEFAULTS_DISPATCHER_RELATION_NAME))
 
     def is_k8s_service_accounts_manifests_related(self) -> bool:
         """Is the charm related to a serviceaccounts manifests relation."""
-        return bool(
-            self.state.charm.model.relations.get(SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME)
-        )
+        return bool(self.charm.model.relations.get(SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME))
 
     def is_k8s_roles_manifests_related(self) -> bool:
         """Is the charm related to a roles manifests relation."""
-        return bool(self.state.charm.model.relations.get(ROLES_DISPATCHER_RELATION_NAME))
+        return bool(self.charm.model.relations.get(ROLES_DISPATCHER_RELATION_NAME))
 
     def is_k8s_rolebindings_manifests_related(self) -> bool:
         """Is the charm related to a rolebindings manifests relation."""
-        return bool(self.state.charm.model.relations.get(ROLEBINDINGS_DISPATCHER_RELATION_NAME))
+        return bool(self.charm.model.relations.get(ROLEBINDINGS_DISPATCHER_RELATION_NAME))
 
     def is_manifests_provider_related(self):
         """Is the charm related to any manifests relation provider."""
         return any(
             [
-                self.is_k8s_poddefaults_manifests_related,
-                self.is_k8s_secrets_manifests_related,
-                self.is_k8s_service_accounts_manifests_related,
-                self.is_k8s_roles_manifests_related,
-                self.is_k8s_rolebindings_manifests_related,
+                self.is_k8s_poddefaults_manifests_related(),
+                self.is_k8s_secrets_manifests_related(),
+                self.is_k8s_service_accounts_manifests_related(),
+                self.is_k8s_roles_manifests_related(),
+                self.is_k8s_rolebindings_manifests_related(),
             ]
         )

--- a/src/events/general.py
+++ b/src/events/general.py
@@ -2,50 +2,16 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""Handler for General Kubeflow-integrator charm events."""
+"""Handler for general charm lifecycle events."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from charms.data_platform_libs.v0.data_interfaces import (
-    DatabaseCreatedEvent,
-    DatabaseEntityCreatedEvent,
-    DatabaseRequires,
-    IndexCreatedEvent,
-    IndexEntityCreatedEvent,
-    KafkaRequires,
-    OpenSearchRequires,
-    TopicCreatedEvent,
-    TopicEntityCreatedEvent,
-)
-from charms.resource_dispatcher.v0.kubernetes_manifests import (
-    KubernetesManifestRequirerWrapper,  # type: ignore
-)
-from charms.spark_integration_hub_k8s.v0.spark_service_account import (
-    ServiceAccountGoneEvent,
-    ServiceAccountGrantedEvent,
-    ServiceAccountPropertyChangedEvent,
-    SparkServiceAccountRequirer,
-)
-from ops import Object, RelationBrokenEvent
+from ops import Object
 from ops.charm import ConfigChangedEvent
 
-from constants import (
-    KAFKA_RELATION_NAME,
-    MONGODB_RELATION_NAME,
-    MYSQL_RELATION_NAME,
-    OPENSEARCH_RELATION_NAME,
-    POD_DEFAULTS_DISPATCHER_RELATION_NAME,
-    POSTGRESQL_RLEATION_NAME,
-    ROLEBINDINGS_DISPATCHER_RELATION_NAME,
-    ROLES_DISPATCHER_RELATION_NAME,
-    SECRETS_DISPATCHER_RELATION_NAME,
-    SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME,
-    SPARK_RELATION_NAME,
-)
 from core.state import GlobalState
-from managers.manifests import ReconciledManifests
 from utils.logging import WithLogging
 
 if TYPE_CHECKING:
@@ -53,7 +19,7 @@ if TYPE_CHECKING:
 
 
 class GeneralEventsHandler(Object, WithLogging):
-    """Class implementing Kubeflow-integrator events handling."""
+    """Class implementing general charm lifecycle events handling."""
 
     def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
         super().__init__(charm, key="general")
@@ -63,218 +29,37 @@ class GeneralEventsHandler(Object, WithLogging):
 
         self.framework.observe(self.charm.on.config_changed, self._on_config_changed)
 
-        ## databases
-        self.opensearch = OpenSearchRequires(
-            self.charm,
-            OPENSEARCH_RELATION_NAME,
-            getattr(self.state.opensearch_config, "index_name", ""),
-            extra_user_roles=getattr(self.state.opensearch_config, "extra_user_roles", ""),
-        )
-        self.kafka = KafkaRequires(
-            self.charm,
-            relation_name=KAFKA_RELATION_NAME,
-            topic=getattr(self.state.kafka_config, "topic_name", ""),
-            extra_user_roles=getattr(self.state.kafka_config, "extra_user_roles", ""),
-            consumer_group_prefix=getattr(self.state.kafka_config, "consumer_group_prefix", ""),
-        )
-
-        self.postgresql = DatabaseRequires(
-            self.charm,
-            relation_name=POSTGRESQL_RLEATION_NAME,
-            database_name=getattr(self.state.postgresql_config, "database_name", ""),
-            extra_user_roles=getattr(self.state.postgresql_config, "extra_user_roles", ""),
-        )
-        self.mysql = DatabaseRequires(
-            self.charm,
-            relation_name=MYSQL_RELATION_NAME,
-            database_name=getattr(self.state.mysql_config, "database_name", ""),
-            extra_user_roles=getattr(self.state.mysql_config, "extra_user_roles", ""),
-        )
-        self.mongodb = DatabaseRequires(
-            self.charm,
-            relation_name=MONGODB_RELATION_NAME,
-            database_name=getattr(self.state.mysql_config, "database_name", ""),
-            extra_user_roles=getattr(self.state.mysql_config, "extra_user_roles", ""),
-        )
-        profile = getattr(self.state.profile_config, "profile", "")
-        namespace = profile if profile != "*" else self.charm.model.name
-        username = getattr(self.state.spark_config, "spark_service_account", "")
-        self.spark = SparkServiceAccountRequirer(
-            self.charm,
-            relation_name=SPARK_RELATION_NAME,
-            service_account=f"{namespace}:{username}",
-            skip_creation=True,
-        )
-        for database in [self.postgresql, self.mysql, self.mongodb]:
-            self.framework.observe(database.on.database_created, self._on_database_created)
-            self.framework.observe(
-                database.on.database_entity_created, self._on_database_entity_created
-            )
-
-        # opensearch
-        self.framework.observe(self.opensearch.on.index_created, self._on_index_created)
-        self.framework.observe(
-            self.opensearch.on.index_entity_created, self._on_index_entity_created
-        )
-        self.framework.observe(
-            self.charm.on[OPENSEARCH_RELATION_NAME].relation_broken, self._on_relation_broken
-        )
-        # kafka
-        self.framework.observe(self.kafka.on.topic_created, self._on_topic_created)
-        self.framework.observe(self.kafka.on.topic_entity_created, self._on_topic_entity_created)
-        self.framework.observe(
-            self.charm.on[KAFKA_RELATION_NAME].relation_broken, self._on_relation_broken
-        )
-        # spark
-        self.framework.observe(
-            self.spark.on.account_granted, self._on_spark_service_account_granted
-        )
-        self.framework.observe(self.spark.on.account_gone, self._on_spark_service_account_gone)
-        self.framework.observe(self.spark.on.properties_changed, self._on_spark_properties_changed)
-
-        # resource-dispatcher manifests
-        self.secrets_manifests_wrapper = KubernetesManifestRequirerWrapper(
-            charm=self.charm, relation_name=SECRETS_DISPATCHER_RELATION_NAME
-        )
-        self.service_accounts_manifests_wrapper = KubernetesManifestRequirerWrapper(
-            charm=self.charm, relation_name=SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME
-        )
-        self.pod_defaults_manifests_wrapper = KubernetesManifestRequirerWrapper(
-            charm=self.charm, relation_name=POD_DEFAULTS_DISPATCHER_RELATION_NAME
-        )
-        self.roles_manifests_wrapper = KubernetesManifestRequirerWrapper(
-            charm=self.charm, relation_name=ROLES_DISPATCHER_RELATION_NAME
-        )
-        self.role_bindings_manifests_wrapper = KubernetesManifestRequirerWrapper(
-            charm=self.charm, relation_name=ROLEBINDINGS_DISPATCHER_RELATION_NAME
-        )
-
-        # resource-dispatcher
-        for relation_name in [
-            SECRETS_DISPATCHER_RELATION_NAME,
-            SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME,
-            POD_DEFAULTS_DISPATCHER_RELATION_NAME,
-            ROLES_DISPATCHER_RELATION_NAME,
-            ROLEBINDINGS_DISPATCHER_RELATION_NAME,
-        ]:
-            self.framework.observe(
-                self.charm.on[relation_name].relation_created,
-                self._on_manifests_relation_change,
-            )
-            self.framework.observe(
-                self.charm.on[relation_name].relation_changed,
-                self._on_manifests_relation_change,
-            )
-
-    def _on_manifests_relation_change(self, _):
-        """Event handler for when any of the manifests relations change."""
-        # Only execute in the unit leader
-        if not self.charm.unit.is_leader():
-            return
-
-        reconciled_manifests = ReconciledManifests()
-        if self.charm.manifests_manager.is_manifests_provider_related:
-            # Reconcile opensearch manifests
-            opensearch_manifests = self.charm.opensearch_manager.generate_manifests()
-            postgresql_manifests = self.charm.postgresql_manager.generate_manifests()
-            mysql_manifests = self.charm.mysql_manager.generate_manifests()
-            mongodb_manifests = self.charm.mongodb_manager.generate_manifests()
-            kafka_manifests = self.charm.kafka_manager.generate_manifests()
-            spark_manifests = self.charm.spark_manager.generate_manifests()
-            reconciled_manifests = (
-                reconciled_manifests
-                + opensearch_manifests
-                + postgresql_manifests
-                + mysql_manifests
-                + mongodb_manifests
-                + kafka_manifests
-                + spark_manifests
-            )
-
-        # TODO: Reconcile other Data Platform databases
-
-        self.charm.manifests_manager.send_manifests(reconciled_manifests)
-
-    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
-        """Event triggered when a database is created for either mysql/postgresql/mongodb."""
-        self.logger.debug(f"Database credentials are received: {event.username}")
-        self._on_config_changed(event)
-
-    def _on_database_entity_created(self, event: DatabaseEntityCreatedEvent) -> None:
-        """Event triggered when a database entity is created for either mysql/postgresql/mongodb."""
-        self.logger.debug(f"Database entity credentials are received: {event.entity_name}")
-        self._on_config_changed(event)
-
-    def _on_index_created(self, event: IndexCreatedEvent) -> None:
-        """Event triggered when an index is created for this application."""
-        self.logger.debug(f"OpenSearch credentials are received: {event.username}")
-        self._on_config_changed(event)
-
-    def _on_index_entity_created(self, event: IndexEntityCreatedEvent) -> None:
-        """Event triggered when an entity is created for this application."""
-        self.logger.debug(f"Entity credentials are received: {event.entity_name}")
-        self._on_config_changed(event)
-
-    def _on_topic_created(self, event: TopicCreatedEvent) -> None:
-        """Event triggered when a topic is created for this application."""
-        self.logger.debug(f"Topic is created and credentials received {event.username}")
-        self._on_config_changed(event)
-
-    def _on_topic_entity_created(self, event: TopicEntityCreatedEvent) -> None:
-        """Event triggered when an entity is created for this application."""
-        self.logger.debug(f"Entity credentials are received: {event.entity_name}")
-        self._on_config_changed(event)
-
-    def _on_spark_service_account_granted(self, event: ServiceAccountGrantedEvent) -> None:
-        """Event triggered when a service account has been created and granted for this application."""
-        self.logger.debug(f"Spark service account is granted: {event.service_account}")
-        self._on_config_changed(event)
-
-    def _on_spark_service_account_gone(self, event: ServiceAccountGoneEvent) -> None:
-        """Event triggered when a service account has been released."""
-        self.logger.debug("Spark service account is gone.")
-        self._on_config_changed(event)
-
-    def _on_spark_properties_changed(self, event: ServiceAccountPropertyChangedEvent) -> None:
-        """Event triggered when the Spark properties for a service account has been changed."""
-        self.logger.debug(
-            f"Spark properties for the service account is changed: {event.service_account}"
-        )
-        self._on_config_changed(event)
-
-    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Handle relation broken event."""
-        pass
-
     def _on_config_changed(self, event: ConfigChangedEvent) -> None:
         """Event handler for configuration changed events."""
         # Only execute in the unit leader
         if not self.charm.unit.is_leader():
             return
+
         self.logger.debug(f"Config changed... Current configuration: {self.charm.config}")
 
-        if self.state.opensearch_config and not self.charm.opensearch_manager.index_active:
+        if self.state.opensearch_config and not self.state.active_opensearch_index:
             # route the config change to appropriate handler
-            self.charm.opensearch_manager.update_relation_data()
+            self.charm.opensearch_events.update_relation_data()
 
-        if self.state.postgresql_config and not self.charm.postgresql_manager.database_active:
+        if self.state.postgresql_config and not self.state.active_postgresql_database:
             # route the config change to postgresql manager
-            self.charm.postgresql_manager.update_relation_data()
+            self.charm.postgres_events.update_relation_data()
 
-        if self.state.mysql_config and not self.charm.mysql_manager.database_active:
+        if self.state.mysql_config and not self.state.active_mysql_database:
             # route the config change to mysql manager
-            self.charm.mysql_manager.update_relation_data()
+            self.charm.mysql_events.update_relation_data()
 
-        if self.state.mongodb_config and not self.charm.mongodb_manager.database_active:
+        if self.state.mongodb_config and not self.state.active_mongodb_database:
             # route the config change to mongodb manager
-            self.charm.mongodb_manager.update_relation_data()
-        if self.state.kafka_config and not self.charm.kafka_manager.topic_active:
+            self.charm.mongodb_events.update_relation_data()
+
+        if self.state.kafka_config and not self.state.active_kafka_topic:
             # route the config change to kafka manager
-            self.charm.kafka_manager.update_relation_data()
+            self.charm.kafka_events.update_relation_data()
 
         if self.state.spark_config:
             # route the config change to spark manager
-            self.charm.spark_manager.update_relation_data()
+            self.charm.spark_events.update_relation_data()
 
         # reconcile manifests
-        self._on_manifests_relation_change(event)
+        self.charm.manifest_events._on_manifests_relation_change(event)

--- a/src/events/general.py
+++ b/src/events/general.py
@@ -43,7 +43,7 @@ class GeneralEventsHandler(Object, WithLogging):
 
         if self.state.postgresql_config and not self.state.active_postgresql_database:
             # route the config change to postgresql manager
-            self.charm.postgres_events.update_relation_data()
+            self.charm.postgresql_events.update_relation_data()
 
         if self.state.mysql_config and not self.state.active_mysql_database:
             # route the config change to mysql manager

--- a/src/events/kafka.py
+++ b/src/events/kafka.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for Kafka related events."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    KafkaRequirerEventHandlers,
+    TopicCreatedEvent,
+    TopicEntityCreatedEvent,
+)
+from ops import Object, RelationBrokenEvent
+
+from constants import (
+    KAFKA_RELATION_NAME,
+)
+from core.state import GlobalState
+from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KubeflowIntegratorCharm
+
+
+class KafkaEventsHandler(Object, WithLogging):
+    """Class implementing Kafka events handling."""
+
+    def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
+        super().__init__(charm, key="kafka")
+        self.charm = charm
+        self.state = state
+
+        self.kafka = KafkaRequirerEventHandlers(self.charm, self.state.kafka_requirer)
+
+        self.framework.observe(self.kafka.on.topic_created, self._on_topic_created)
+        self.framework.observe(self.kafka.on.topic_entity_created, self._on_topic_entity_created)
+        self.framework.observe(
+            self.charm.on[KAFKA_RELATION_NAME].relation_broken, self._on_relation_broken
+        )
+
+    def _on_topic_created(self, event: TopicCreatedEvent) -> None:
+        """Event triggered when a topic is created for this application."""
+        self.logger.debug(f"Topic is created and credentials received {event.username}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_topic_entity_created(self, event: TopicEntityCreatedEvent) -> None:
+        """Event triggered when an entity is created for this application."""
+        self.logger.debug(f"Entity credentials are received: {event.entity_name}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle relation broken event."""
+        pass
+
+    def update_relation_data(self) -> None:
+        """Update kafka relation data with latest config."""
+        kafka_config = self.state.kafka_config
+        if kafka_config:
+            relation_data = {
+                "topic": kafka_config.topic_name if kafka_config else "",
+                "extra-user-roles": kafka_config.extra_user_roles or "",
+                "consumer-group-prefix": kafka_config.consumer_group_prefix or "",
+            }
+            for rel in self.kafka.relations:
+                self.kafka.update_relation_data(rel.id, relation_data)

--- a/src/events/kafka.py
+++ b/src/events/kafka.py
@@ -64,5 +64,5 @@ class KafkaEventsHandler(Object, WithLogging):
                 "extra-user-roles": kafka_config.extra_user_roles or "",
                 "consumer-group-prefix": kafka_config.consumer_group_prefix or "",
             }
-            for rel in self.kafka.relations:
+            for rel in self.state.kafka_requirer.relations:
                 self.kafka.update_relation_data(rel.id, relation_data)

--- a/src/events/manifest.py
+++ b/src/events/manifest.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for K8s resource manifest related events."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from charms.resource_dispatcher.v0.kubernetes_manifests import (
+    KubernetesManifestRequirerWrapper,  # type: ignore
+)
+from ops import Object
+
+from constants import (
+    POD_DEFAULTS_DISPATCHER_RELATION_NAME,
+    ROLEBINDINGS_DISPATCHER_RELATION_NAME,
+    ROLES_DISPATCHER_RELATION_NAME,
+    SECRETS_DISPATCHER_RELATION_NAME,
+    SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME,
+)
+from core.state import GlobalState
+from utils.k8s_models import ReconciledManifests
+from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KubeflowIntegratorCharm
+
+
+class ManifestEventsHandler(Object, WithLogging):
+    """Class implementing K8s resource manifest events handling."""
+
+    def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
+        super().__init__(charm, key="general")
+
+        self.charm = charm
+        self.state = state
+
+        # resource-dispatcher manifests
+        self.secrets_manifests_wrapper = KubernetesManifestRequirerWrapper(
+            charm=self.charm, relation_name=SECRETS_DISPATCHER_RELATION_NAME
+        )
+        self.service_accounts_manifests_wrapper = KubernetesManifestRequirerWrapper(
+            charm=self.charm, relation_name=SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME
+        )
+        self.pod_defaults_manifests_wrapper = KubernetesManifestRequirerWrapper(
+            charm=self.charm, relation_name=POD_DEFAULTS_DISPATCHER_RELATION_NAME
+        )
+        self.roles_manifests_wrapper = KubernetesManifestRequirerWrapper(
+            charm=self.charm, relation_name=ROLES_DISPATCHER_RELATION_NAME
+        )
+        self.role_bindings_manifests_wrapper = KubernetesManifestRequirerWrapper(
+            charm=self.charm, relation_name=ROLEBINDINGS_DISPATCHER_RELATION_NAME
+        )
+
+        # resource-dispatcher
+        for relation_name in [
+            SECRETS_DISPATCHER_RELATION_NAME,
+            SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME,
+            POD_DEFAULTS_DISPATCHER_RELATION_NAME,
+            ROLES_DISPATCHER_RELATION_NAME,
+            ROLEBINDINGS_DISPATCHER_RELATION_NAME,
+        ]:
+            self.framework.observe(
+                self.charm.on[relation_name].relation_created,
+                self._on_manifests_relation_change,
+            )
+            self.framework.observe(
+                self.charm.on[relation_name].relation_changed,
+                self._on_manifests_relation_change,
+            )
+
+    def _on_manifests_relation_change(self, _):
+        """Event handler for when any of the manifests relations change."""
+        # Only execute in the unit leader
+        if not self.charm.unit.is_leader():
+            return
+
+        reconciled_manifests = ReconciledManifests()
+        if self.state.is_manifests_provider_related():
+            # Reconcile opensearch manifests
+            opensearch_manifests = self.charm.opensearch_manager.generate_manifests()
+            postgresql_manifests = self.charm.postgresql_manager.generate_manifests()
+            mysql_manifests = self.charm.mysql_manager.generate_manifests()
+            mongodb_manifests = self.charm.mongodb_manager.generate_manifests()
+            kafka_manifests = self.charm.kafka_manager.generate_manifests()
+            spark_manifests = self.charm.spark_manager.generate_manifests()
+            reconciled_manifests = (
+                reconciled_manifests
+                + opensearch_manifests
+                + postgresql_manifests
+                + mysql_manifests
+                + mongodb_manifests
+                + kafka_manifests
+                + spark_manifests
+            )
+
+        # TODO: Reconcile other Data Platform databases
+
+        self.send_manifests(reconciled_manifests)
+
+    def send_manifests(self, reconciled_manifests: ReconciledManifests):
+        """Send k8s manifests to the manifests provider."""
+        self.secrets_manifests_wrapper.send_data(reconciled_manifests.secrets)
+        self.pod_defaults_manifests_wrapper.send_data(reconciled_manifests.poddefaults)
+        self.service_accounts_manifests_wrapper.send_data(reconciled_manifests.serviceaccounts)
+        self.roles_manifests_wrapper.send_data(reconciled_manifests.roles)
+        self.role_bindings_manifests_wrapper.send_data(reconciled_manifests.role_bindings)

--- a/src/events/mongodb.py
+++ b/src/events/mongodb.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for MongoDB related events."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseCreatedEvent,
+    DatabaseEntityCreatedEvent,
+    DatabaseRequirerEventHandlers,
+)
+from ops import Object, RelationBrokenEvent
+
+from constants import (
+    MONGODB_RELATION_NAME,
+)
+from core.state import GlobalState
+from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KubeflowIntegratorCharm
+
+
+class MongoDBEventsHandler(Object, WithLogging):
+    """Class implementing MongoDB events handling."""
+
+    def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
+        super().__init__(charm, key="mongodb")
+        self.charm = charm
+        self.state = state
+
+        self.mongodb = DatabaseRequirerEventHandlers(self.charm, self.state.mongodb_requirer)
+
+        self.framework.observe(self.mongodb.on.database_created, self._on_database_created)
+        self.framework.observe(
+            self.mongodb.on.database_entity_created, self._on_database_entity_created
+        )
+        self.framework.observe(
+            self.charm.on[MONGODB_RELATION_NAME].relation_broken, self._on_relation_broken
+        )
+
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+        """Event triggered when a database is created for mongodb."""
+        self.logger.debug(f"Database credentials are received: {event.username}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_database_entity_created(self, event: DatabaseEntityCreatedEvent) -> None:
+        """Event triggered when a database entity is created for mongodb."""
+        self.logger.debug(f"Database entity credentials are received: {event.entity_name}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle relation broken event."""
+        pass
+
+    def update_relation_data(self) -> None:
+        """Update mongodb relation data with latest config."""
+        if self.state.mongodb_config:
+            relation_data = {
+                "database": self.state.mongodb_config.database_name
+                if self.state.mongodb_config
+                else "",
+                "extra-user-roles": self.state.mongodb_config.extra_user_roles or "",
+            }
+            for rel in self.mongodb.relations:
+                self.mongodb.update_relation_data(rel.id, relation_data)

--- a/src/events/mongodb.py
+++ b/src/events/mongodb.py
@@ -66,5 +66,5 @@ class MongoDBEventsHandler(Object, WithLogging):
                 else "",
                 "extra-user-roles": self.state.mongodb_config.extra_user_roles or "",
             }
-            for rel in self.mongodb.relations:
+            for rel in self.state.mongodb_requirer.relations:
                 self.mongodb.update_relation_data(rel.id, relation_data)

--- a/src/events/mysql.py
+++ b/src/events/mysql.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for MySQL related events."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseCreatedEvent,
+    DatabaseEntityCreatedEvent,
+    DatabaseRequirerEventHandlers,
+)
+from ops import Object, RelationBrokenEvent
+
+from constants import (
+    MYSQL_RELATION_NAME,
+)
+from core.state import GlobalState
+from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KubeflowIntegratorCharm
+
+
+class MySQLEventsHandler(Object, WithLogging):
+    """Class implementing MySQL events handling."""
+
+    def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
+        super().__init__(charm, key="mysql")
+        self.charm = charm
+        self.state = state
+
+        self.mysql = DatabaseRequirerEventHandlers(self.charm, self.state.mysql_requirer)
+
+        self.framework.observe(self.mysql.on.database_created, self._on_database_created)
+        self.framework.observe(
+            self.mysql.on.database_entity_created, self._on_database_entity_created
+        )
+        self.framework.observe(
+            self.charm.on[MYSQL_RELATION_NAME].relation_broken, self._on_relation_broken
+        )
+
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+        """Event triggered when a database is created for mysql."""
+        self.logger.debug(f"Database credentials are received: {event.username}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_database_entity_created(self, event: DatabaseEntityCreatedEvent) -> None:
+        """Event triggered when a database entity is created for mysql."""
+        self.logger.debug(f"Database entity credentials are received: {event.entity_name}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle relation broken event."""
+        pass
+
+    def update_relation_data(self) -> None:
+        """Update mysql relation data with latest config."""
+        if self.state.mysql_config:
+            relation_data = {
+                "database": self.state.mysql_config.database_name
+                if self.state.mysql_config
+                else "",
+                "extra-user-roles": self.state.mysql_config.extra_user_roles or "",
+            }
+            for rel in self.mysql.relations:
+                self.mysql.update_relation_data(rel.id, relation_data)

--- a/src/events/mysql.py
+++ b/src/events/mysql.py
@@ -66,5 +66,5 @@ class MySQLEventsHandler(Object, WithLogging):
                 else "",
                 "extra-user-roles": self.state.mysql_config.extra_user_roles or "",
             }
-            for rel in self.mysql.relations:
+            for rel in self.state.mysql_requirer.relations:
                 self.mysql.update_relation_data(rel.id, relation_data)

--- a/src/events/opensearch.py
+++ b/src/events/opensearch.py
@@ -68,5 +68,5 @@ class OpenSearchEventsHandler(Object, WithLogging):
                 "index": opensearch_config.index_name if opensearch_config else "",
                 "extra-user-roles": opensearch_config.extra_user_roles or "",
             }
-            for rel in self.opensearch.relations:
+            for rel in self.state.opensearch_requirer.relations:
                 self.opensearch.update_relation_data(rel.id, relation_data)

--- a/src/events/opensearch.py
+++ b/src/events/opensearch.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for Opensearch related events."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    IndexCreatedEvent,
+    IndexEntityCreatedEvent,
+    OpenSearchRequiresEventHandlers,
+)
+from ops import Object, RelationBrokenEvent
+
+from constants import (
+    OPENSEARCH_RELATION_NAME,
+)
+from core.state import GlobalState
+from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KubeflowIntegratorCharm
+
+
+class OpenSearchEventsHandler(Object, WithLogging):
+    """Class implementing Opensearch events handling."""
+
+    def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
+        super().__init__(charm, key="opensearch")
+
+        self.charm = charm
+        self.state = state
+
+        self.opensearch = OpenSearchRequiresEventHandlers(
+            self.charm, self.state.opensearch_requirer
+        )
+
+        self.framework.observe(self.opensearch.on.index_created, self._on_index_created)
+        self.framework.observe(
+            self.opensearch.on.index_entity_created, self._on_index_entity_created
+        )
+        self.framework.observe(
+            self.charm.on[OPENSEARCH_RELATION_NAME].relation_broken, self._on_relation_broken
+        )
+
+    def _on_index_created(self, event: IndexCreatedEvent) -> None:
+        """Event triggered when an index is created for this application."""
+        self.logger.debug(f"OpenSearch credentials are received: {event.username}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_index_entity_created(self, event: IndexEntityCreatedEvent) -> None:
+        """Event triggered when an entity is created for this application."""
+        self.logger.debug(f"Entity credentials are received: {event.entity_name}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle relation broken event."""
+        pass
+
+    def update_relation_data(self) -> None:
+        """Update opensearch relation data with latest config."""
+        opensearch_config = self.state.opensearch_config
+        if opensearch_config:
+            relation_data = {
+                "index": opensearch_config.index_name if opensearch_config else "",
+                "extra-user-roles": opensearch_config.extra_user_roles or "",
+            }
+            for rel in self.opensearch.relations:
+                self.opensearch.update_relation_data(rel.id, relation_data)

--- a/src/events/postgres.py
+++ b/src/events/postgres.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for Postgres related events."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseCreatedEvent,
+    DatabaseEntityCreatedEvent,
+    DatabaseRequirerEventHandlers,
+)
+from ops import Object, RelationBrokenEvent
+
+from constants import (
+    POSTGRESQL_RLEATION_NAME,
+)
+from core.state import GlobalState
+from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KubeflowIntegratorCharm
+
+
+class PostgresEventsHandler(Object, WithLogging):
+    """Class implementing Postgres events handling."""
+
+    def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
+        super().__init__(charm, key="postgres")
+
+        self.charm = charm
+        self.state = state
+
+        self.postgresql = DatabaseRequirerEventHandlers(self.charm, self.state.postgresql_requirer)
+
+        self.framework.observe(self.postgresql.on.database_created, self._on_database_created)
+        self.framework.observe(
+            self.postgresql.on.database_entity_created, self._on_database_entity_created
+        )
+        self.framework.observe(
+            self.charm.on[POSTGRESQL_RLEATION_NAME].relation_broken, self._on_relation_broken
+        )
+
+    def _on_database_created(self, event: DatabaseCreatedEvent) -> None:
+        """Event triggered when a database is created for postgresql."""
+        self.logger.debug(f"Database credentials are received: {event.username}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_database_entity_created(self, event: DatabaseEntityCreatedEvent) -> None:
+        """Event triggered when a database entity is created for postgresql."""
+        self.logger.debug(f"Database entity credentials are received: {event.entity_name}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle relation broken event."""
+        pass
+
+    def update_relation_data(self) -> None:
+        """Update opensearch relation data with latest config."""
+        if self.state.postgresql_config:
+            relation_data = {
+                "database": self.state.postgresql_config.database_name
+                if self.state.postgresql_config
+                else "",
+                "extra-user-roles": self.state.postgresql_config.extra_user_roles or "",
+            }
+            for rel in self.postgresql.relations:
+                self.postgresql.update_relation_data(rel.id, relation_data)

--- a/src/events/postgres.py
+++ b/src/events/postgres.py
@@ -59,7 +59,7 @@ class PostgresEventsHandler(Object, WithLogging):
         pass
 
     def update_relation_data(self) -> None:
-        """Update opensearch relation data with latest config."""
+        """Update postgresql relation data with latest config."""
         if self.state.postgresql_config:
             relation_data = {
                 "database": self.state.postgresql_config.database_name

--- a/src/events/postgres.py
+++ b/src/events/postgres.py
@@ -67,5 +67,5 @@ class PostgresEventsHandler(Object, WithLogging):
                 else "",
                 "extra-user-roles": self.state.postgresql_config.extra_user_roles or "",
             }
-            for rel in self.postgresql.relations:
+            for rel in self.state.postgresql_requirer.relations:
                 self.postgresql.update_relation_data(rel.id, relation_data)

--- a/src/events/postgresql.py
+++ b/src/events/postgresql.py
@@ -25,11 +25,11 @@ if TYPE_CHECKING:
     from charm import KubeflowIntegratorCharm
 
 
-class PostgresEventsHandler(Object, WithLogging):
+class PostgresqlEventsHandler(Object, WithLogging):
     """Class implementing Postgres events handling."""
 
     def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
-        super().__init__(charm, key="postgres")
+        super().__init__(charm, key="postgresql")
 
         self.charm = charm
         self.state = state

--- a/src/events/spark.py
+++ b/src/events/spark.py
@@ -16,9 +16,6 @@ from charms.spark_integration_hub_k8s.v0.spark_service_account import (
 )
 from ops import Object
 
-from constants import (
-    SPARK_RELATION_NAME,
-)
 from core.state import GlobalState
 from utils.logging import WithLogging
 
@@ -74,4 +71,4 @@ class SparkEventsHandler(Object, WithLogging):
                 "skip-creation": "true",
             }
             for rel in self.state.spark_requirer.relations:
-                self.spark.update_relation_data(rel.id, relation_data)
+                self.state.spark_requirer.update_relation_data(rel.id, relation_data)

--- a/src/events/spark.py
+++ b/src/events/spark.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Handler for Spark related events."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from charms.spark_integration_hub_k8s.v0.spark_service_account import (
+    ServiceAccountGoneEvent,
+    ServiceAccountGrantedEvent,
+    ServiceAccountPropertyChangedEvent,
+    SparkServiceAccountRequirerEventHandlers,
+)
+from ops import Object
+
+from constants import (
+    SPARK_RELATION_NAME,
+)
+from core.state import GlobalState
+from utils.logging import WithLogging
+
+if TYPE_CHECKING:
+    from charm import KubeflowIntegratorCharm
+
+
+class SparkEventsHandler(Object, WithLogging):
+    """Class implementing Spark events handling."""
+
+    def __init__(self, charm: KubeflowIntegratorCharm, state: GlobalState):
+        super().__init__(charm, key="spark")
+        self.charm = charm
+        self.state = state
+
+        self.spark = SparkServiceAccountRequirerEventHandlers(
+            self.charm, self.state.spark_requirer
+        )
+
+        self.framework.observe(
+            self.spark.on.account_granted, self._on_spark_service_account_granted
+        )
+        self.framework.observe(self.spark.on.account_gone, self._on_spark_service_account_gone)
+        self.framework.observe(self.spark.on.properties_changed, self._on_spark_properties_changed)
+
+    def _on_spark_service_account_granted(self, event: ServiceAccountGrantedEvent) -> None:
+        """Event triggered when a service account has been created and granted for this application."""
+        self.logger.debug(f"Spark service account is granted: {event.service_account}")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_spark_service_account_gone(self, event: ServiceAccountGoneEvent) -> None:
+        """Event triggered when a service account has been released."""
+        self.logger.debug("Spark service account is gone.")
+        self.charm.general_events._on_config_changed(event)
+
+    def _on_spark_properties_changed(self, event: ServiceAccountPropertyChangedEvent) -> None:
+        """Event triggered when the Spark properties for a service account has been changed."""
+        self.logger.debug(
+            f"Spark properties for the service account is changed: {event.service_account}"
+        )
+        self.charm.general_events._on_config_changed(event)
+
+    def update_relation_data(self) -> None:
+        """Update spark relation data with latest config."""
+        spark_config = self.state.spark_config
+        profile_config = self.state.profile_config
+        if spark_config and profile_config:
+            username = spark_config.spark_service_account
+            profile = profile_config.profile
+            namespace = profile if profile != "*" else self.charm.model.name
+            relation_data = {
+                "service-account": f"{namespace}:{username}",
+                "skip-creation": "true",
+            }
+            for rel in self.state.spark_requirer.relations:
+                self.spark.update_relation_data(rel.id, relation_data)

--- a/src/managers/database.py
+++ b/src/managers/database.py
@@ -6,14 +6,28 @@
 
 from abc import ABC, abstractmethod
 
-from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires
+from charms.data_platform_libs.v0.data_interfaces import RequirerData
+from charms.resource_dispatcher.v0.kubernetes_manifests import (
+    KubernetesManifest,  # type: ignore[import-untyped]
+)
 
-from core.config import MongoDbConfig, MysqlConfig, PostgresqlConfig
+from constants import (
+    K8S_DATABASE_SECRET_NAME,
+    K8S_DATABASE_TLS_CERT_PATH,
+    K8S_DATABASE_TLS_SECRET_NAME,
+)
+from core.config import MongoDbConfig, MysqlConfig, PostgresqlConfig, OpenSearchConfig
 from core.state import GlobalState
+from managers.manifests import KubernetesManifestsManager
+from utils.helpers_manifests import (
+    generate_poddefault_manifest,
+    generate_secret_manifest,
+    generate_tls_secret_manifest,
+)
 from utils.k8s_models import ReconciledManifests
 from utils.logging import WithLogging
 
-DatabaseConfig = MysqlConfig | PostgresqlConfig | MongoDbConfig
+DatabaseConfig = MysqlConfig | PostgresqlConfig | MongoDbConfig | OpenSearchConfig
 
 
 class DatabaseManager(WithLogging, ABC):
@@ -22,27 +36,7 @@ class DatabaseManager(WithLogging, ABC):
     def __init__(self, state: GlobalState, name: str):
         self.state = state
         self.name = name
-
-    def update_relation_data(self) -> None:
-        """Update opensearch relation data with latest config."""
-        if self.database_config:
-            relation_data = {
-                "database": self.database_config.database_name if self.database_config else "",
-                "extra-user-roles": self.database_config.extra_user_roles or "",
-            }
-            for rel in self.database_requirer.relations:
-                self.database_requirer.update_relation_data(rel.id, relation_data)
-
-    def generate_manifests(self) -> ReconciledManifests:
-        """Generate kubernetes manifesets for the current credentials."""
-        if self.is_database_related and self.database_active:
-            # Fetch credentials
-            database_creds = list(self.database_requirer.fetch_relation_data().values())[0]
-            return self.state.charm.manifests_manager.reconcile_database_manifests(
-                database_creds, self.name
-            )
-
-        return ReconciledManifests()
+        self.manifest_manager = KubernetesManifestsManager(state)
 
     @property
     @abstractmethod
@@ -51,27 +45,78 @@ class DatabaseManager(WithLogging, ABC):
 
     @property
     @abstractmethod
-    def database_requirer(self) -> DatabaseRequires:
-        """Return the databaseRequires instance from event handlers."""
+    def database_requirer(self) -> RequirerData:
+        """Return the RequirerData instance from event handlers."""
 
     @property
-    def database_active(self) -> str | None:
+    @abstractmethod
+    def active_database(self) -> str | None:
         """Return the created and configured database."""
-        if (
-            relation := self.database_requirer.relations[0]
-            if len(self.database_requirer.relations)
-            else None
-        ):
-            return self.database_requirer.fetch_relation_field(relation.id, "database")
-        return None
 
-    @property
+    @abstractmethod
     def is_database_related(self) -> bool:
         """Check if we have a relation with the database."""
-        for relation in self.database_requirer.relations:
-            data = self.database_requirer.fetch_relation_data(
-                [relation.id], ["username", "password"]
-            ).get(relation.id, {})
-            if all(data.get(key) for key in ("username", "password")):
-                return True
-        return False
+
+    def generate_manifests(self) -> ReconciledManifests:
+        """Generate kubernetes manifesets for the current credentials."""
+        if not (self.is_database_related() and self.active_database):
+            return ReconciledManifests()
+
+        if not self.state.profile_config:
+            self.logger.warning("No specified profile, skipping manifests generation")
+            return ReconciledManifests()
+
+        # Fetch credentials
+        creds = list(self.database_requirer.fetch_relation_data().values())[0]
+        database_name = self.name
+
+        database_secret: KubernetesManifest | None = None
+        tls_secret: KubernetesManifest | None = None
+        secrets_manifests: list[KubernetesManifest] = []
+        poddefault_manifests: list[KubernetesManifest] = []
+
+        # remove data field from the credentials
+        if "data" in creds:
+            creds.pop("data", None)
+
+        # generate secrets manifests
+        if self.state.is_k8s_secrets_manifests_related():
+            secret_data = creds.copy()
+            tls_secret = generate_tls_secret_manifest(
+                self.manifest_manager.secret_k8s_template,
+                self.state.profile_config.profile,
+                creds,
+                database_name,
+            )
+            if tls_secret:
+                secrets_manifests.append(tls_secret)
+                # Add a path to the mounted tls
+                secret_data["ca_cert_path"] = K8S_DATABASE_TLS_CERT_PATH[database_name]
+                # Remove "tls-ca" from creds
+                secret_data.pop("tls-ca")
+
+            database_secret = generate_secret_manifest(
+                self.manifest_manager.secret_k8s_template,
+                self.state.profile_config.profile,
+                secret_data,
+                database_name,
+            )
+            secrets_manifests.append(database_secret)
+
+        # generate pod defaults
+        if self.state.is_k8s_poddefaults_manifests_related():
+            # If a tls-secret was generated, we include the cert path in pod default
+            if tls_secret:
+                creds["ca_cert_path"] = K8S_DATABASE_TLS_CERT_PATH[database_name]
+                creds.pop("tls-ca")
+
+            poddefault = generate_poddefault_manifest(
+                self.manifest_manager.poddefault_k8s_template,
+                self.state.profile_config.profile,
+                creds,
+                database_name,
+                from_secret=K8S_DATABASE_SECRET_NAME[database_name] if database_secret else None,
+                tls_secret=K8S_DATABASE_TLS_SECRET_NAME[database_name] if tls_secret else None,
+            )
+            poddefault_manifests.append(poddefault)
+        return ReconciledManifests(secrets=secrets_manifests, poddefaults=poddefault_manifests)

--- a/src/managers/database.py
+++ b/src/managers/database.py
@@ -16,7 +16,7 @@ from constants import (
     K8S_DATABASE_TLS_CERT_PATH,
     K8S_DATABASE_TLS_SECRET_NAME,
 )
-from core.config import MongoDbConfig, MysqlConfig, PostgresqlConfig, OpenSearchConfig
+from core.config import MongoDbConfig, MysqlConfig, OpenSearchConfig, PostgresqlConfig
 from core.state import GlobalState
 from managers.manifests import KubernetesManifestsManager
 from utils.helpers_manifests import (

--- a/src/managers/kafka.py
+++ b/src/managers/kafka.py
@@ -4,7 +4,7 @@
 
 """Manager for kafka related tasks."""
 
-from charms.data_platform_libs.v0.data_interfaces import KafkaRequires
+from charms.data_platform_libs.v0.data_interfaces import KafkaRequirerData
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
@@ -14,7 +14,6 @@ from constants import KAFKA
 from core.config import KafkaConfig
 from core.state import GlobalState
 from core.statuses import CharmStatuses, ConfigStatuses
-from utils.k8s_models import ReconciledManifests
 from utils.logging import WithLogging
 
 
@@ -25,27 +24,24 @@ class KafkaManager(ManagerStatusProtocol, WithLogging):
         self.name = KAFKA
         self.state = state
 
-    def update_relation_data(self) -> None:
-        """Update kafka relation data with latest config."""
-        kafka_config = self.state.kafka_config
-        if kafka_config:
-            relation_data = {
-                "topic": kafka_config.topic_name if kafka_config else "",
-                "extra-user-roles": kafka_config.extra_user_roles or "",
-                "consumer-group-prefix": kafka_config.consumer_group_prefix or "",
-            }
-            for rel in self.kafka_requirer.relations:
-                self.kafka_requirer.update_relation_data(rel.id, relation_data)
+    @property
+    def database_requirer(self) -> KafkaRequirerData:
+        """Return kafka_requirer data component."""
+        return self.state.kafka_requirer
 
-    def generate_manifests(self) -> ReconciledManifests:
-        """Generate kubernetes manifesets for the current credentials."""
-        if self.is_kafka_related and self.topic_active:
-            # Fetch credentials
-            kafka_creds = list(self.kafka_requirer.fetch_relation_data().values())[0]
-            return self.state.charm.manifests_manager.reconcile_database_manifests(
-                kafka_creds, KAFKA
-            )
-        return ReconciledManifests()
+    @property
+    def database_config(self) -> KafkaConfig | None:
+        """Return Kafka config from global state."""
+        return self.state.kafka_config
+
+    @property
+    def active_database(self) -> str | None:
+        """Return the created and configured index."""
+        return self.state.active_kafka_topic
+
+    def is_database_related(self) -> bool:
+        """Check if we have a relation with kafka."""
+        return self.state.is_kafka_related()
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Return the list of statuses for this component."""
@@ -59,7 +55,7 @@ class KafkaManager(ManagerStatusProtocol, WithLogging):
             self.logger.warning(str(err))
 
             # If kafka is related
-            if len(self.kafka_requirer.relations) > 0:
+            if len(self.state.kafka_requirer.relations) > 0:
                 missing = [
                     str(error["loc"][0]) for error in err.errors() if error["type"] == "missing"
                 ]
@@ -71,35 +67,8 @@ class KafkaManager(ManagerStatusProtocol, WithLogging):
                     status_list.append(ConfigStatuses.missing_config_parameters(fields=missing))
                 if invalid:
                     status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
-        if kafka_config and not self.is_kafka_related:
+        if kafka_config and not self.state.is_kafka_related():
             # Block the charm since we need the integration with kafka
             status_list.append(CharmStatuses.missing_integration_with_kafka())
 
         return status_list or [CharmStatuses.ACTIVE_IDLE.value]
-
-    @property
-    def kafka_requirer(self) -> KafkaRequires:
-        """Return the KafkaRequires instance from event handlers."""
-        return self.state.charm.general_events.kafka
-
-    @property
-    def topic_active(self) -> str | None:
-        """Return the created and configured kafka topic."""
-        if (
-            relation := self.kafka_requirer.relations[0]
-            if len(self.kafka_requirer.relations)
-            else None
-        ):
-            return self.kafka_requirer.fetch_relation_field(relation.id, "topic")
-        return None
-
-    @property
-    def is_kafka_related(self) -> bool:
-        """Check if we have a relation with Kafka."""
-        for relation in self.kafka_requirer.relations:
-            data = self.kafka_requirer.fetch_relation_data(
-                [relation.id], ["username", "password"]
-            ).get(relation.id, {})
-            if all(data.get(key) for key in ("username", "password")):
-                return True
-        return False

--- a/src/managers/kafka.py
+++ b/src/managers/kafka.py
@@ -14,15 +14,14 @@ from constants import KAFKA
 from core.config import KafkaConfig
 from core.state import GlobalState
 from core.statuses import CharmStatuses, ConfigStatuses
-from utils.logging import WithLogging
+from managers.database import DatabaseManager
 
 
-class KafkaManager(ManagerStatusProtocol, WithLogging):
+class KafkaManager(DatabaseManager, ManagerStatusProtocol):
     """Manager for Kafka relation."""
 
     def __init__(self, state: GlobalState):
-        self.name = KAFKA
-        self.state = state
+        super().__init__(state, KAFKA)
 
     @property
     def database_requirer(self) -> KafkaRequirerData:

--- a/src/managers/manifests.py
+++ b/src/managers/manifests.py
@@ -6,46 +6,16 @@
 
 import os
 
-import yaml
-from charms.resource_dispatcher.v0.kubernetes_manifests import (
-    KubernetesManifest,  # type: ignore[import-untyped]
-)
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
 from jinja2 import Environment, FileSystemLoader, Template
 from pydantic import ValidationError
 
-from constants import (
-    K8S_DATABASE_SECRET_NAME,
-    K8S_DATABASE_TLS_CERT_PATH,
-    K8S_DATABASE_TLS_SECRET_NAME,
-    POD_DEFAULTS_DISPATCHER_RELATION_NAME,
-    ROLEBINDINGS_DISPATCHER_RELATION_NAME,
-    ROLES_DISPATCHER_RELATION_NAME,
-    SECRETS_DISPATCHER_RELATION_NAME,
-    SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME,
-    SPARK,
-    SPARK_BLOCK_MANAGER_PORT,
-    SPARK_DRIVER_PORT,
-    SPARK_NOTEBOOK_PODDEFAULT_DESC,
-    SPARK_NOTEBOOK_PODDEFAULT_NAME,
-    SPARK_NOTEBOOK_PODDEFAULT_SELECTOR_LABEL,
-    SPARK_PIPELINE_PODDEFAULT_DESC,
-    SPARK_PIPELINE_PODDEFAULT_NAME,
-    SPARK_PIPELINE_PODDEFAULT_SELECTOR_LABEL,
-)
+
 from core.config import ProfileConfig
 from core.state import GlobalState
 from core.statuses import CharmStatuses, ConfigStatuses
-from utils.helpers_manifests import (
-    generate_poddefault_manifest,
-    generate_secret_manifest,
-    generate_tls_secret_manifest,
-)
-from utils.k8s_models import (
-    ReconciledManifests,
-)
 from utils.logging import WithLogging
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -65,188 +35,6 @@ class KubernetesManifestsManager(ManagerStatusProtocol, WithLogging):
             trim_blocks=True,
             lstrip_blocks=True,
         )
-
-    def reconcile_database_manifests(
-        self, creds: dict[str, str], database_name: str
-    ) -> ReconciledManifests:
-        """Generate manifests for OpenSearch/Mysql/Postgresql/Mongodb databases."""
-        if not self.state.profile_config:
-            self.logger.warning("No specified profile, skipping manifests generation")
-            return ReconciledManifests()
-
-        database_secret: KubernetesManifest | None = None
-        tls_secret: KubernetesManifest | None = None
-        secrets_manifests: list[KubernetesManifest] = []
-        poddefault_manifests: list[KubernetesManifest] = []
-
-        # remove data field from the credentials
-        if "data" in creds:
-            creds.pop("data", None)
-
-        # generate secrets manifests
-        if self.is_k8s_secrets_manifests_related:
-            secret_data = creds.copy()
-            tls_secret = generate_tls_secret_manifest(
-                self.secret_k8s_template,
-                self.state.profile_config.profile,
-                creds,
-                database_name,
-            )
-            if tls_secret:
-                secrets_manifests.append(tls_secret)
-                # Add a path to the mounted tls
-                secret_data["ca_cert_path"] = K8S_DATABASE_TLS_CERT_PATH[database_name]
-                # Remove "tls-ca" from creds
-                secret_data.pop("tls-ca")
-
-            database_secret = generate_secret_manifest(
-                self.secret_k8s_template,
-                self.state.profile_config.profile,
-                secret_data,
-                database_name,
-            )
-            secrets_manifests.append(database_secret)
-        # generate pod defaults
-        if self.is_k8s_poddefaults_manifests_related:
-            # If a tls-secret was generated, we include the cert path in pod default
-            if tls_secret:
-                creds["ca_cert_path"] = K8S_DATABASE_TLS_CERT_PATH[database_name]
-                creds.pop("tls-ca")
-
-            poddefault = generate_poddefault_manifest(
-                self.poddefault_k8s_template,
-                self.state.profile_config.profile,
-                creds,
-                database_name,
-                from_secret=K8S_DATABASE_SECRET_NAME[database_name] if database_secret else None,
-                tls_secret=K8S_DATABASE_TLS_SECRET_NAME[database_name] if tls_secret else None,
-            )
-            poddefault_manifests.append(poddefault)
-        return ReconciledManifests(secrets=secrets_manifests, poddefaults=poddefault_manifests)
-
-    def _patch_rolebinding_subject_namespace(self, rolebinding: dict) -> dict:
-        """Patch the namespace of the subject in the rolebinding."""
-        if len(rolebinding.get("subjects", [])) == 0:
-            return rolebinding
-
-        for subject in rolebinding["subjects"]:
-            if "namespace" not in subject:
-                continue
-            subject["namespace"] = "{{ NAMESPACE }}"
-
-        return rolebinding
-
-    def reconcile_spark_manifests(
-        self, raw_manifests: str, service_account: str
-    ) -> ReconciledManifests:
-        """Generate manifests for Spark interface."""
-        if not self.state.profile_config:
-            self.logger.warning("No specified profile, skipping manifests generation")
-            return ReconciledManifests()
-
-        manifest_yaml = list(yaml.safe_load_all(raw_manifests))
-
-        secrets_manifests: list[KubernetesManifest] = (
-            [
-                KubernetesManifest(manifest_content=yaml.dump(res))
-                for res in manifest_yaml
-                if res["kind"] == "Secret"
-            ]
-            if self.is_k8s_secrets_manifests_related
-            else []
-        )
-
-        service_accounts_manifest: list[KubernetesManifest] = (
-            [
-                KubernetesManifest(manifest_content=yaml.dump(res))
-                for res in manifest_yaml
-                if res["kind"] == "ServiceAccount"
-            ]
-            if self.is_k8s_service_accounts_manifests_related
-            else []
-        )
-
-        roles_manifest: list[KubernetesManifest] = (
-            [
-                KubernetesManifest(manifest_content=yaml.dump(res))
-                for res in manifest_yaml
-                if res["kind"] == "Role"
-            ]
-            if self.is_k8s_roles_manifests_related
-            else []
-        )
-
-        rolebindings_manifest: list[KubernetesManifest] = (
-            [
-                KubernetesManifest(
-                    manifest_content=yaml.dump(self._patch_rolebinding_subject_namespace(res))
-                )
-                for res in manifest_yaml
-                if res["kind"] == "RoleBinding"
-            ]
-            if self.is_k8s_rolebindings_manifests_related
-            else []
-        )
-
-        spark_pipeline_poddefault = generate_poddefault_manifest(
-            self.poddefault_k8s_template,
-            self.state.profile_config.profile,
-            creds={"SPARK_SERVICE_ACCOUNT": service_account},
-            database_name=SPARK,
-            poddefault_name=SPARK_PIPELINE_PODDEFAULT_NAME,
-            poddefault_description=SPARK_PIPELINE_PODDEFAULT_DESC,
-            fieldrefs={"SPARK_NAMESPACE": "metadata.namespace"},
-            selector_name=SPARK_PIPELINE_PODDEFAULT_SELECTOR_LABEL,
-        )
-        spark_notebook_poddefault = generate_poddefault_manifest(
-            self.poddefault_k8s_template,
-            self.state.profile_config.profile,
-            creds={"SPARK_SERVICE_ACCOUNT": service_account},
-            database_name=SPARK,
-            poddefault_name=SPARK_NOTEBOOK_PODDEFAULT_NAME,
-            poddefault_description=SPARK_NOTEBOOK_PODDEFAULT_DESC,
-            args=[
-                "--namespace",
-                "$SPARK_NAMESPACE",
-                "--username",
-                "$SPARK_SERVICE_ACCOUNT",
-                "--conf",
-                f"spark.driver.port={SPARK_DRIVER_PORT}",
-                "--conf",
-                f"spark.blockManager.port={SPARK_BLOCK_MANAGER_PORT}",
-                "--conf",
-                f"spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeInboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
-                "--conf",
-                f"spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeOutboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
-            ],
-            annotations={
-                "traffic.sidecar.istio.io/excludeInboundPorts": f"{SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
-                "traffic.sidecar.istio.io/excludeOutboundPorts": f"{SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
-            },
-            fieldrefs={"SPARK_NAMESPACE": "metadata.namespace"},
-            selector_name=SPARK_NOTEBOOK_PODDEFAULT_SELECTOR_LABEL,
-        )
-        poddefaults_manifest = (
-            [spark_pipeline_poddefault, spark_notebook_poddefault]
-            if self.is_k8s_poddefaults_manifests_related
-            else []
-        )
-
-        return ReconciledManifests(
-            secrets=secrets_manifests,
-            poddefaults=poddefaults_manifest,
-            serviceaccounts=service_accounts_manifest,
-            roles=roles_manifest,
-            role_bindings=rolebindings_manifest,
-        )
-
-    def send_manifests(self, reconciled_manifests: ReconciledManifests):
-        """Send k8s manifests to the manifests provider."""
-        self.manifests_secret_wrapper.send_data(reconciled_manifests.secrets)
-        self.manifests_poddefault_wrapper.send_data(reconciled_manifests.poddefaults)
-        self.manifests_service_account_wrapper.send_data(reconciled_manifests.serviceaccounts)
-        self.manifests_roles_wrapper.send_data(reconciled_manifests.roles)
-        self.manifests_rolebindings_wrapper.send_data(reconciled_manifests.role_bindings)
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Return the list of statuses for this component."""
@@ -268,71 +56,6 @@ class KubernetesManifestsManager(ManagerStatusProtocol, WithLogging):
                 status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
 
         return status_list or [CharmStatuses.ACTIVE_IDLE.value]
-
-    @property
-    def manifests_secret_wrapper(self):
-        """Return the Manifests Secret Wrapper."""
-        return self.state.charm.general_events.secrets_manifests_wrapper
-
-    @property
-    def manifests_poddefault_wrapper(self):
-        """Return the Manifests PodDefault Wrapper."""
-        return self.state.charm.general_events.pod_defaults_manifests_wrapper
-
-    @property
-    def manifests_service_account_wrapper(self):
-        """Return the Manifests Service Account Wrapper."""
-        return self.state.charm.general_events.service_accounts_manifests_wrapper
-
-    @property
-    def manifests_roles_wrapper(self):
-        """Return the Manifests Roles Wrapper."""
-        return self.state.charm.general_events.roles_manifests_wrapper
-
-    @property
-    def manifests_rolebindings_wrapper(self):
-        """Return the Manifests Role Bindings Wrapper."""
-        return self.state.charm.general_events.role_bindings_manifests_wrapper
-
-    @property
-    def is_manifests_provider_related(self):
-        """Is the charm related to any manifests relation provider."""
-        return any(
-            [
-                self.is_k8s_poddefaults_manifests_related,
-                self.is_k8s_secrets_manifests_related,
-                self.is_k8s_service_accounts_manifests_related,
-                self.is_k8s_roles_manifests_related,
-                self.is_k8s_rolebindings_manifests_related,
-            ]
-        )
-
-    @property
-    def is_k8s_secrets_manifests_related(self) -> bool:
-        """Is the charm related to a secrets manifests relation."""
-        return bool(self.state.charm.model.relations.get(SECRETS_DISPATCHER_RELATION_NAME))
-
-    @property
-    def is_k8s_poddefaults_manifests_related(self) -> bool:
-        """Is the charm related to a poddefaults manifests relation."""
-        return bool(self.state.charm.model.relations.get(POD_DEFAULTS_DISPATCHER_RELATION_NAME))
-
-    @property
-    def is_k8s_service_accounts_manifests_related(self) -> bool:
-        """Is the charm related to a serviceaccounts manifests relation."""
-        return bool(
-            self.state.charm.model.relations.get(SERVICE_ACCOUNTS_DISPATCHER_RELATION_NAME)
-        )
-
-    @property
-    def is_k8s_roles_manifests_related(self) -> bool:
-        """Is the charm related to a roles manifests relation."""
-        return bool(self.state.charm.model.relations.get(ROLES_DISPATCHER_RELATION_NAME))
-
-    @property
-    def is_k8s_rolebindings_manifests_related(self) -> bool:
-        """Is the charm related to a rolebindings manifests relation."""
-        return bool(self.state.charm.model.relations.get(ROLEBINDINGS_DISPATCHER_RELATION_NAME))
 
     @property
     def secret_k8s_template(self) -> Template:

--- a/src/managers/manifests.py
+++ b/src/managers/manifests.py
@@ -6,16 +6,9 @@
 
 import os
 
-from data_platform_helpers.advanced_statuses.models import StatusObject
-from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
-from data_platform_helpers.advanced_statuses.types import Scope
 from jinja2 import Environment, FileSystemLoader, Template
-from pydantic import ValidationError
 
-
-from core.config import ProfileConfig
 from core.state import GlobalState
-from core.statuses import CharmStatuses, ConfigStatuses
 from utils.logging import WithLogging
 
 CURRENT_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -23,7 +16,7 @@ SRC_DIR = os.path.dirname(CURRENT_DIR)
 TEMPLATE_DIR = os.path.join(SRC_DIR, "templates")
 
 
-class KubernetesManifestsManager(ManagerStatusProtocol, WithLogging):
+class KubernetesManifestsManager(WithLogging):
     """Manager for Kubernetes Manifests Generation and communication with 'resource-dispatcher'."""
 
     def __init__(self, state: GlobalState):
@@ -35,27 +28,6 @@ class KubernetesManifestsManager(ManagerStatusProtocol, WithLogging):
             trim_blocks=True,
             lstrip_blocks=True,
         )
-
-    def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
-        """Return the list of statuses for this component."""
-        status_list = []
-        try:
-            ProfileConfig(**self.state.charm.config)
-        except ValidationError as err:
-            self.logger.error(f"A validation error occurred {err}")
-            missing = [
-                str(error["loc"][0]) for error in err.errors() if error["type"] == "missing"
-            ]
-            invalid = [
-                str(error["loc"][0]) for error in err.errors() if error["type"] != "missing"
-            ]
-
-            if missing:
-                status_list.append(ConfigStatuses.missing_config_parameters(fields=missing))
-            if invalid:
-                status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
-
-        return status_list or [CharmStatuses.ACTIVE_IDLE.value]
 
     @property
     def secret_k8s_template(self) -> Template:

--- a/src/managers/mongodb.py
+++ b/src/managers/mongodb.py
@@ -32,6 +32,15 @@ class MongodbManager(DatabaseManager, ManagerStatusProtocol):
         """Returns mongodb config from the global state."""
         return self.state.mongodb_config
 
+    @property
+    def active_database(self) -> str | None:
+        """Return the created and configured database."""
+        return self.state.active_mongodb_database
+
+    def is_database_related(self) -> bool:
+        """Check if we have a relation with mongodb."""
+        return self.state.is_mongodb_related()
+
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Return the list of statuses for this component."""
         status_list = []

--- a/src/managers/mongodb.py
+++ b/src/managers/mongodb.py
@@ -4,7 +4,7 @@
 
 """Manager for MongoDB related tasks."""
 
-from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires, Scope
+from charms.data_platform_libs.v0.data_interfaces import DatabaseRequirerData, Scope
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from pydantic import ValidationError
@@ -23,9 +23,9 @@ class MongodbManager(DatabaseManager, ManagerStatusProtocol):
         super().__init__(state, MONGODB)
 
     @property
-    def database_requirer(self) -> DatabaseRequires:
-        """Returns DatabaseRequires from events handler."""
-        return self.state.charm.general_events.mongodb
+    def database_requirer(self) -> DatabaseRequirerData:
+        """Returns DatabaseRequirerData from events handler."""
+        return self.state.mongodb_requirer
 
     @property
     def database_config(self) -> MongoDbConfig | None:
@@ -64,7 +64,7 @@ class MongodbManager(DatabaseManager, ManagerStatusProtocol):
                     status_list.append(ConfigStatuses.missing_config_parameters(fields=missing))
                 if invalid:
                     status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
-        if database_config and not self.is_database_related:
+        if database_config and not self.is_database_related():
             # Block the charm since we need the integration with opensearch
             status_list.append(CharmStatuses.missing_integration_with_mongodb())
 

--- a/src/managers/mysql.py
+++ b/src/managers/mysql.py
@@ -32,6 +32,15 @@ class MysqlManager(DatabaseManager, ManagerStatusProtocol):
         """Returns the mysql config from the global state."""
         return self.state.mysql_config
 
+    @property
+    def active_database(self) -> str | None:
+        """Return the created and configured database."""
+        return self.state.active_mysql_database
+
+    def is_database_related(self) -> bool:
+        """Check if we have a relation with mysql."""
+        return self.state.is_mysql_related()
+
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Return the list of statuses for this component."""
         status_list = []

--- a/src/managers/mysql.py
+++ b/src/managers/mysql.py
@@ -4,7 +4,7 @@
 
 """Manager for Mysql related tasks."""
 
-from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires, Scope
+from charms.data_platform_libs.v0.data_interfaces import DatabaseRequirerData, Scope
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from pydantic import ValidationError
@@ -23,9 +23,9 @@ class MysqlManager(DatabaseManager, ManagerStatusProtocol):
         super().__init__(state, MYSQL)
 
     @property
-    def database_requirer(self) -> DatabaseRequires:
+    def database_requirer(self) -> DatabaseRequirerData:
         """Returns the DatabaseRequires from events handler."""
-        return self.state.charm.general_events.mysql
+        return self.state.mysql_requirer
 
     @property
     def database_config(self) -> MysqlConfig | None:
@@ -64,7 +64,7 @@ class MysqlManager(DatabaseManager, ManagerStatusProtocol):
                     status_list.append(ConfigStatuses.missing_config_parameters(fields=missing))
                 if invalid:
                     status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
-        if database_config and not self.is_database_related:
+        if database_config and not self.is_database_related():
             # Block the charm since we need the integration with opensearch
             status_list.append(CharmStatuses.missing_integration_with_mysql())
 

--- a/src/managers/opensearch.py
+++ b/src/managers/opensearch.py
@@ -14,16 +14,15 @@ from constants import OPENSEARCH
 from core.config import OpenSearchConfig
 from core.state import GlobalState
 from core.statuses import CharmStatuses, ConfigStatuses
-from utils.logging import WithLogging
 from managers.database import DatabaseManager
+from utils.logging import WithLogging
 
 
 class OpenSearchManager(DatabaseManager, ManagerStatusProtocol, WithLogging):
     """Manager for Opensearch relation."""
 
     def __init__(self, state: GlobalState):
-        self.name = OPENSEARCH
-        self.state = state
+        super().__init__(state, OPENSEARCH)
 
     @property
     def database_requirer(self) -> OpenSearchRequiresData:
@@ -67,7 +66,7 @@ class OpenSearchManager(DatabaseManager, ManagerStatusProtocol, WithLogging):
                     status_list.append(ConfigStatuses.missing_config_parameters(fields=missing))
                 if invalid:
                     status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
-        if opensearch_config and not self.is_opensearch_related:
+        if opensearch_config and not self.state.is_opensearch_related():
             # Block the charm since we need the integration with opensearch
             status_list.append(CharmStatuses.missing_integration_with_opensearch())
 

--- a/src/managers/opensearch.py
+++ b/src/managers/opensearch.py
@@ -4,7 +4,7 @@
 
 """Manager for opensearch related tasks."""
 
-from charms.data_platform_libs.v0.data_interfaces import OpenSearchRequires
+from charms.data_platform_libs.v0.data_interfaces import OpenSearchRequiresData
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
@@ -14,37 +14,35 @@ from constants import OPENSEARCH
 from core.config import OpenSearchConfig
 from core.state import GlobalState
 from core.statuses import CharmStatuses, ConfigStatuses
-from utils.k8s_models import ReconciledManifests
 from utils.logging import WithLogging
+from managers.database import DatabaseManager
 
 
-class OpenSearchManager(ManagerStatusProtocol, WithLogging):
+class OpenSearchManager(DatabaseManager, ManagerStatusProtocol, WithLogging):
     """Manager for Opensearch relation."""
 
     def __init__(self, state: GlobalState):
         self.name = OPENSEARCH
         self.state = state
 
-    def update_relation_data(self) -> None:
-        """Update opensearch relation data with latest config."""
-        opensearch_config = self.state.opensearch_config
-        if opensearch_config:
-            relation_data = {
-                "index": opensearch_config.index_name if opensearch_config else "",
-                "extra-user-roles": opensearch_config.extra_user_roles or "",
-            }
-            for rel in self.opensearch_requirer.relations:
-                self.opensearch_requirer.update_relation_data(rel.id, relation_data)
+    @property
+    def database_requirer(self) -> OpenSearchRequiresData:
+        """Return opensearch_requirer data component."""
+        return self.state.opensearch_requirer
 
-    def generate_manifests(self) -> ReconciledManifests:
-        """Generate kubernetes manifesets for the current credentials."""
-        if self.is_opensearch_related and self.index_active:
-            # Fetch credentials
-            opensearch_creds = list(self.opensearch_requirer.fetch_relation_data().values())[0]
-            return self.state.charm.manifests_manager.reconcile_database_manifests(
-                opensearch_creds, OPENSEARCH
-            )
-        return ReconciledManifests()
+    @property
+    def database_config(self) -> OpenSearchConfig | None:
+        """Return Opensearch config from global state."""
+        return self.state.opensearch_config
+
+    @property
+    def active_database(self) -> str | None:
+        """Return the created and configured index."""
+        return self.state.active_opensearch_index
+
+    def is_database_related(self) -> bool:
+        """Check if we have a relation with opensearch."""
+        return self.state.is_opensearch_related()
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Return the list of statuses for this component."""
@@ -57,7 +55,7 @@ class OpenSearchManager(ManagerStatusProtocol, WithLogging):
             self.logger.warning(str(err))
 
             # If opensearch is related
-            if len(self.opensearch_requirer.relations) > 0:
+            if len(self.state.opensearch_requirer.relations) > 0:
                 missing = [
                     str(error["loc"][0]) for error in err.errors() if error["type"] == "missing"
                 ]
@@ -74,30 +72,3 @@ class OpenSearchManager(ManagerStatusProtocol, WithLogging):
             status_list.append(CharmStatuses.missing_integration_with_opensearch())
 
         return status_list or [CharmStatuses.ACTIVE_IDLE.value]
-
-    @property
-    def opensearch_requirer(self) -> OpenSearchRequires:
-        """Return the opensearchRequires instance from event handlers."""
-        return self.state.charm.general_events.opensearch
-
-    @property
-    def index_active(self) -> str | None:
-        """Return the created and configured opensearch index."""
-        if (
-            relation := self.opensearch_requirer.relations[0]
-            if len(self.opensearch_requirer.relations)
-            else None
-        ):
-            return self.opensearch_requirer.fetch_relation_field(relation.id, "index")
-        return None
-
-    @property
-    def is_opensearch_related(self) -> bool:
-        """Check if we have a relation with OpenSearch."""
-        for relation in self.opensearch_requirer.relations:
-            data = self.opensearch_requirer.fetch_relation_data(
-                [relation.id], ["username", "password"]
-            ).get(relation.id, {})
-            if all(data.get(key) for key in ("username", "password")):
-                return True
-        return False

--- a/src/managers/postgresql.py
+++ b/src/managers/postgresql.py
@@ -4,7 +4,7 @@
 
 """Manager for Postgresql related tasks."""
 
-from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires, Scope
+from charms.data_platform_libs.v0.data_interfaces import DatabaseRequirerData, Scope
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from pydantic import ValidationError
@@ -23,14 +23,23 @@ class PostgresqlManager(DatabaseManager, ManagerStatusProtocol):
         super().__init__(state, POSTGRESQL)
 
     @property
-    def database_requirer(self) -> DatabaseRequires:
-        """Return Databaserequires from events handler."""
-        return self.state.charm.general_events.postgresql
+    def database_requirer(self) -> DatabaseRequirerData:
+        """Return PostgreSQL RequirerData component."""
+        return self.state.postgresql_requirer
 
     @property
     def database_config(self) -> PostgresqlConfig | None:
         """Return postgresql config from global state."""
         return self.state.postgresql_config
+
+    @property
+    def active_database(self) -> str | None:
+        """Return the created and configured database."""
+        return self.state.active_postgresql_database
+
+    def is_database_related(self) -> bool:
+        """Check if we have a relation with postgresql."""
+        return self.state.is_postgresql_related()
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Return the list of statuses for this component."""

--- a/src/managers/postgresql.py
+++ b/src/managers/postgresql.py
@@ -65,7 +65,7 @@ class PostgresqlManager(DatabaseManager, ManagerStatusProtocol):
                 if invalid:
                     status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
 
-        if database_config and not self.is_database_related:
+        if database_config and not self.is_database_related():
             # Block the charm since we need the integration with postgresql
             status_list.append(CharmStatuses.missing_integration_with_postgresql())
 

--- a/src/managers/profile.py
+++ b/src/managers/profile.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Manager for Kubeflow profiles."""
+
+from data_platform_helpers.advanced_statuses.models import StatusObject
+from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
+from data_platform_helpers.advanced_statuses.types import Scope
+from pydantic import ValidationError
+
+from core.config import ProfileConfig
+from core.state import GlobalState
+from core.statuses import CharmStatuses, ConfigStatuses
+from utils.logging import WithLogging
+
+
+class KubeflowProfileManager(ManagerStatusProtocol, WithLogging):
+    """Manager for Kubeflow profile."""
+
+    def __init__(self, state: GlobalState):
+        self.name = "profile"
+        self.state = state
+
+    def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
+        """Return the list of statuses for this component."""
+        status_list = []
+        try:
+            ProfileConfig(**self.state.charm.config)
+        except ValidationError as err:
+            self.logger.error(f"A validation error occurred {err}")
+            missing = [
+                str(error["loc"][0]) for error in err.errors() if error["type"] == "missing"
+            ]
+            invalid = [
+                str(error["loc"][0]) for error in err.errors() if error["type"] != "missing"
+            ]
+
+            if missing:
+                status_list.append(ConfigStatuses.missing_config_parameters(fields=missing))
+            if invalid:
+                status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
+
+        return status_list or [CharmStatuses.ACTIVE_IDLE.value]

--- a/src/managers/spark.py
+++ b/src/managers/spark.py
@@ -4,7 +4,7 @@
 
 """Manager for Spark related tasks."""
 
-from typing import cast
+from typing import Callable, cast
 
 import yaml
 from charms.resource_dispatcher.v0.kubernetes_manifests import (
@@ -97,14 +97,20 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
         return rolebinding
 
     def filter_manifests(
-        self, manifest_yaml: list[dict], kind: str, manifest_relation_exists: bool
+        self,
+        manifest_yaml: list[dict],
+        kind: str,
+        manifest_relation_exists: bool,
+        patch_function: Callable | None = None,
     ) -> list[KubernetesManifest]:
         """Filter the manifests of given kind from the given list of resource objects."""
         if not manifest_relation_exists:
             return []
 
         return [
-            KubernetesManifest(manifest_content=yaml.dump(res))
+            KubernetesManifest(
+                manifest_content=yaml.dump(patch_function(res) if patch_function else res)
+            )
             for res in manifest_yaml
             if res["kind"] == kind
         ]
@@ -142,7 +148,10 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
             manifest_yaml, "Role", self.state.is_k8s_roles_manifests_related()
         )
         rolebindings_manifest = self.filter_manifests(
-            manifest_yaml, "RoleBinding", self.state.is_k8s_rolebindings_manifests_related()
+            manifest_yaml,
+            "RoleBinding",
+            self.state.is_k8s_rolebindings_manifests_related(),
+            patch_function=self._patch_rolebinding_subject_namespace,
         )
 
         spark_pipeline_poddefault = generate_poddefault_manifest(

--- a/src/managers/spark.py
+++ b/src/managers/spark.py
@@ -10,7 +10,6 @@ import yaml
 from charms.resource_dispatcher.v0.kubernetes_manifests import (
     KubernetesManifest,  # type: ignore[import-untyped]
 )
-from charms.spark_integration_hub_k8s.v0.spark_service_account import SparkServiceAccountRequirer
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
@@ -31,6 +30,7 @@ from constants import (
 from core.config import SparkConfig
 from core.state import GlobalState
 from core.statuses import CharmStatuses, ConfigStatuses
+from managers.manifests import KubernetesManifestsManager
 from utils.helpers_manifests import generate_poddefault_manifest
 from utils.k8s_models import ReconciledManifests
 from utils.logging import WithLogging
@@ -42,6 +42,7 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
     def __init__(self, state: GlobalState):
         self.name = SPARK
         self.state = state
+        self.manifest_manager = KubernetesManifestsManager(state)
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Return the list of statuses for this component."""
@@ -95,9 +96,22 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
 
         return rolebinding
 
+    def filter_manifests(
+        self, manifest_yaml: list[dict], kind: str, manifest_relation_exists: bool
+    ) -> list[KubernetesManifest]:
+        """Filter the manifests of given kind from the given list of resource objects."""
+        if not manifest_relation_exists:
+            return []
+
+        return [
+            KubernetesManifest(manifest_content=yaml.dump(res))
+            for res in manifest_yaml
+            if res["kind"] == kind
+        ]
+
     def generate_manifests(self) -> ReconciledManifests:
         """Generate kubernetes manifests for the current spark relation."""
-        if not (self.state.is_spark_related() and self.state.service_account_active):
+        if not (self.state.is_spark_related() and self.state.active_spark_service_account):
             return ReconciledManifests()
 
         # Fetch manifest from the relation
@@ -118,50 +132,21 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
 
         manifest_yaml = list(yaml.safe_load_all(raw_manifests))
 
-        secrets_manifests: list[KubernetesManifest] = (
-            [
-                KubernetesManifest(manifest_content=yaml.dump(res))
-                for res in manifest_yaml
-                if res["kind"] == "Secret"
-            ]
-            if self.is_k8s_secrets_manifests_related
-            else []
+        secrets_manifests = self.filter_manifests(
+            manifest_yaml, "Secret", self.state.is_k8s_secrets_manifests_related()
         )
-
-        service_accounts_manifest: list[KubernetesManifest] = (
-            [
-                KubernetesManifest(manifest_content=yaml.dump(res))
-                for res in manifest_yaml
-                if res["kind"] == "ServiceAccount"
-            ]
-            if self.is_k8s_service_accounts_manifests_related
-            else []
+        service_accounts_manifest = self.filter_manifests(
+            manifest_yaml, "ServiceAccount", self.state.is_k8s_service_accounts_manifests_related()
         )
-
-        roles_manifest: list[KubernetesManifest] = (
-            [
-                KubernetesManifest(manifest_content=yaml.dump(res))
-                for res in manifest_yaml
-                if res["kind"] == "Role"
-            ]
-            if self.is_k8s_roles_manifests_related
-            else []
+        roles_manifest = self.filter_manifests(
+            manifest_yaml, "Role", self.state.is_k8s_roles_manifests_related()
         )
-
-        rolebindings_manifest: list[KubernetesManifest] = (
-            [
-                KubernetesManifest(
-                    manifest_content=yaml.dump(self._patch_rolebinding_subject_namespace(res))
-                )
-                for res in manifest_yaml
-                if res["kind"] == "RoleBinding"
-            ]
-            if self.is_k8s_rolebindings_manifests_related
-            else []
+        rolebindings_manifest = self.filter_manifests(
+            manifest_yaml, "RoleBinding", self.state.is_k8s_rolebindings_manifests_related()
         )
 
         spark_pipeline_poddefault = generate_poddefault_manifest(
-            self.poddefault_k8s_template,
+            self.manifest_manager.poddefault_k8s_template,
             self.state.profile_config.profile,
             creds={"SPARK_SERVICE_ACCOUNT": service_account},
             database_name=SPARK,
@@ -171,7 +156,7 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
             selector_name=SPARK_PIPELINE_PODDEFAULT_SELECTOR_LABEL,
         )
         spark_notebook_poddefault = generate_poddefault_manifest(
-            self.poddefault_k8s_template,
+            self.manifest_manager.poddefault_k8s_template,
             self.state.profile_config.profile,
             creds={"SPARK_SERVICE_ACCOUNT": service_account},
             database_name=SPARK,
@@ -200,7 +185,7 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
         )
         poddefaults_manifest = (
             [spark_pipeline_poddefault, spark_notebook_poddefault]
-            if self.is_k8s_poddefaults_manifests_related
+            if self.state.is_k8s_poddefaults_manifests_related()
             else []
         )
 

--- a/src/managers/spark.py
+++ b/src/managers/spark.py
@@ -6,16 +6,32 @@
 
 from typing import cast
 
+import yaml
+from charms.resource_dispatcher.v0.kubernetes_manifests import (
+    KubernetesManifest,  # type: ignore[import-untyped]
+)
 from charms.spark_integration_hub_k8s.v0.spark_service_account import SparkServiceAccountRequirer
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
 from pydantic import ValidationError
 
-from constants import SPARK, SPARK_RELATION_NAME
+from constants import (
+    SPARK,
+    SPARK_BLOCK_MANAGER_PORT,
+    SPARK_DRIVER_PORT,
+    SPARK_NOTEBOOK_PODDEFAULT_DESC,
+    SPARK_NOTEBOOK_PODDEFAULT_NAME,
+    SPARK_NOTEBOOK_PODDEFAULT_SELECTOR_LABEL,
+    SPARK_PIPELINE_PODDEFAULT_DESC,
+    SPARK_PIPELINE_PODDEFAULT_NAME,
+    SPARK_PIPELINE_PODDEFAULT_SELECTOR_LABEL,
+    SPARK_RELATION_NAME,
+)
 from core.config import SparkConfig
 from core.state import GlobalState
 from core.statuses import CharmStatuses, ConfigStatuses
+from utils.helpers_manifests import generate_poddefault_manifest
 from utils.k8s_models import ReconciledManifests
 from utils.logging import WithLogging
 
@@ -26,41 +42,6 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
     def __init__(self, state: GlobalState):
         self.name = SPARK
         self.state = state
-
-    def update_relation_data(self) -> None:
-        """Update spark relation data with latest config."""
-        spark_config = self.state.spark_config
-        profile_config = self.state.profile_config
-        if spark_config and profile_config:
-            username = spark_config.spark_service_account
-            profile = profile_config.profile
-            namespace = profile if profile != "*" else self.state.charm.model.name
-            relation_data = {
-                "service-account": f"{namespace}:{username}",
-                "skip-creation": "true",
-            }
-            for rel in self.spark_requirer.relations:
-                self.spark_requirer.update_relation_data(rel.id, relation_data)
-
-    def generate_manifests(self) -> ReconciledManifests:
-        """Generate kubernetes manifests for the current spark relation."""
-        if self.is_spark_related and self.service_account_active:
-            # Fetch manifest from the relation
-            relation = self.spark_requirer.relations[0]
-            raw_manifest = list(self.spark_requirer.fetch_relation_data().values())[0][
-                "resource-manifest"
-            ]
-            namespace, service_account = cast(
-                str,
-                self.spark_requirer.fetch_relation_field(
-                    relation_id=relation.id, field="service-account"
-                ),
-            ).split(":")
-
-            return self.state.charm.manifests_manager.reconcile_spark_manifests(
-                raw_manifest, service_account
-            )
-        return ReconciledManifests()
 
     def get_statuses(self, scope: Scope, recompute: bool = False) -> list[StatusObject]:
         """Return the list of statuses for this component."""
@@ -73,7 +54,7 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
             self.logger.warning(str(err))
 
             # If Spark is related
-            if len(self.spark_requirer.relations) > 0:
+            if len(self.state.spark_requirer.relations) > 0:
                 missing = [
                     str(error["loc"][0]) for error in err.errors() if error["type"] == "missing"
                 ]
@@ -85,14 +66,15 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
                     status_list.append(ConfigStatuses.missing_config_parameters(fields=missing))
                 if invalid:
                     status_list.append(ConfigStatuses.invalid_config_parameters(fields=invalid))
-        if spark_config and not self.is_spark_related:
+
+        if spark_config and not self.state.is_spark_related():
             # Block the charm since we need the integration with spark
             status_list.append(CharmStatuses.missing_integration_with_spark())
 
         if (
-            self.is_spark_related
+            self.state.is_spark_related()
             and spark_config
-            and self.service_account_active != spark_config.spark_service_account
+            and self.state.active_spark_service_account != spark_config.spark_service_account
         ):
             status_list.append(
                 ConfigStatuses.config_change_requires_relation_recreation(
@@ -101,41 +83,131 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
             )
         return status_list or [CharmStatuses.ACTIVE_IDLE.value]
 
-    @property
-    def spark_requirer(self) -> SparkServiceAccountRequirer:
-        """Return the SparkServiceAccountRequirer instance from event handlers."""
-        return self.state.charm.general_events.spark
+    def _patch_rolebinding_subject_namespace(self, rolebinding: dict) -> dict:
+        """Patch the namespace of the subject in the rolebinding."""
+        if len(rolebinding.get("subjects", [])) == 0:
+            return rolebinding
 
-    @property
-    def service_account_active(self) -> str | None:
-        """Return the service account that was created and configured."""
-        if (
-            relation := self.spark_requirer.relations[0]
-            if len(self.spark_requirer.relations)
-            else None
-        ):
-            sa_with_namespace = self.spark_requirer.fetch_relation_field(
-                relation.id, "service-account"
-            )
-            if not sa_with_namespace:
-                return None
-            parts = sa_with_namespace.split(":")
-            if len(parts) != 2:
-                return None
-            _, service_account = parts
-            return service_account
-        return None
+        for subject in rolebinding["subjects"]:
+            if "namespace" not in subject:
+                continue
+            subject["namespace"] = "{{ NAMESPACE }}"
 
-    @property
-    def is_spark_related(self) -> bool:
-        """Check if we have a relation with Kafka."""
-        for relation in self.spark_requirer.relations:
-            data = self.spark_requirer.fetch_relation_data(
-                [relation.id], ["service-account", "resource-manifest", "spark-properties"]
-            ).get(relation.id, {})
-            if all(
-                data.get(key)
-                for key in ("service-account", "resource-manifest", "spark-properties")
-            ):
-                return True
-        return False
+        return rolebinding
+
+    def generate_manifests(self) -> ReconciledManifests:
+        """Generate kubernetes manifests for the current spark relation."""
+        if not (self.state.is_spark_related() and self.state.service_account_active):
+            return ReconciledManifests()
+
+        # Fetch manifest from the relation
+        relation = self.state.spark_requirer.relations[0]
+        raw_manifests = list(self.state.spark_requirer.fetch_relation_data().values())[0][
+            "resource-manifest"
+        ]
+        _, service_account = cast(
+            str,
+            self.state.spark_requirer.fetch_relation_field(
+                relation_id=relation.id, field="service-account"
+            ),
+        ).split(":")
+
+        if not self.state.profile_config:
+            self.logger.warning("No specified profile, skipping manifests generation")
+            return ReconciledManifests()
+
+        manifest_yaml = list(yaml.safe_load_all(raw_manifests))
+
+        secrets_manifests: list[KubernetesManifest] = (
+            [
+                KubernetesManifest(manifest_content=yaml.dump(res))
+                for res in manifest_yaml
+                if res["kind"] == "Secret"
+            ]
+            if self.is_k8s_secrets_manifests_related
+            else []
+        )
+
+        service_accounts_manifest: list[KubernetesManifest] = (
+            [
+                KubernetesManifest(manifest_content=yaml.dump(res))
+                for res in manifest_yaml
+                if res["kind"] == "ServiceAccount"
+            ]
+            if self.is_k8s_service_accounts_manifests_related
+            else []
+        )
+
+        roles_manifest: list[KubernetesManifest] = (
+            [
+                KubernetesManifest(manifest_content=yaml.dump(res))
+                for res in manifest_yaml
+                if res["kind"] == "Role"
+            ]
+            if self.is_k8s_roles_manifests_related
+            else []
+        )
+
+        rolebindings_manifest: list[KubernetesManifest] = (
+            [
+                KubernetesManifest(
+                    manifest_content=yaml.dump(self._patch_rolebinding_subject_namespace(res))
+                )
+                for res in manifest_yaml
+                if res["kind"] == "RoleBinding"
+            ]
+            if self.is_k8s_rolebindings_manifests_related
+            else []
+        )
+
+        spark_pipeline_poddefault = generate_poddefault_manifest(
+            self.poddefault_k8s_template,
+            self.state.profile_config.profile,
+            creds={"SPARK_SERVICE_ACCOUNT": service_account},
+            database_name=SPARK,
+            poddefault_name=SPARK_PIPELINE_PODDEFAULT_NAME,
+            poddefault_description=SPARK_PIPELINE_PODDEFAULT_DESC,
+            fieldrefs={"SPARK_NAMESPACE": "metadata.namespace"},
+            selector_name=SPARK_PIPELINE_PODDEFAULT_SELECTOR_LABEL,
+        )
+        spark_notebook_poddefault = generate_poddefault_manifest(
+            self.poddefault_k8s_template,
+            self.state.profile_config.profile,
+            creds={"SPARK_SERVICE_ACCOUNT": service_account},
+            database_name=SPARK,
+            poddefault_name=SPARK_NOTEBOOK_PODDEFAULT_NAME,
+            poddefault_description=SPARK_NOTEBOOK_PODDEFAULT_DESC,
+            args=[
+                "--namespace",
+                "$SPARK_NAMESPACE",
+                "--username",
+                "$SPARK_SERVICE_ACCOUNT",
+                "--conf",
+                f"spark.driver.port={SPARK_DRIVER_PORT}",
+                "--conf",
+                f"spark.blockManager.port={SPARK_BLOCK_MANAGER_PORT}",
+                "--conf",
+                f"spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeInboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
+                "--conf",
+                f"spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeOutboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
+            ],
+            annotations={
+                "traffic.sidecar.istio.io/excludeInboundPorts": f"{SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
+                "traffic.sidecar.istio.io/excludeOutboundPorts": f"{SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
+            },
+            fieldrefs={"SPARK_NAMESPACE": "metadata.namespace"},
+            selector_name=SPARK_NOTEBOOK_PODDEFAULT_SELECTOR_LABEL,
+        )
+        poddefaults_manifest = (
+            [spark_pipeline_poddefault, spark_notebook_poddefault]
+            if self.is_k8s_poddefaults_manifests_related
+            else []
+        )
+
+        return ReconciledManifests(
+            secrets=secrets_manifests,
+            poddefaults=poddefaults_manifest,
+            serviceaccounts=service_accounts_manifest,
+            roles=roles_manifest,
+            role_bindings=rolebindings_manifest,
+        )


### PR DESCRIPTION
Fixes #16 

This PR aims to refactor the charm code base to clearly separate the logic between the various event handlers, the managers, and also to place the relation state data to a central place. This is to make this charm consistent with the pattern we have for other charms like [`spark-integration-hub-k8s`](https://github.com/canonical/spark-integration-hub-k8s-operator/tree/3/edge/src), [`kyuubi-k8s`](https://github.com/canonical/kyuubi-k8s-operator), [`spark-history-server-k8s`](https://github.com/canonical/spark-history-server-k8s-operator/), [`s3-integrator`](https://github.com/canonical/object-storage-integrator/tree/main/s3) etc.

The idea is that the managers should not attempt to read from the relation data directly nor write to the relation data. Also, the manager should also not attempt to listen to the events directly, and have logic that are not closely tied up with the charm lifecycle. On the other hand, the event handlers will be responsible for listening to the events, and writing appropriate handlers for them, delegating to the managers wherever necessary. The accessors for the state of the charm (both in terms of the config and the relations) are moved to a central place called `state`.