### PR TITLE
[MISC] Bump kubernetes_manifests lib to 0.2

### DIFF
--- a/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
+++ b/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
@@ -100,12 +100,12 @@ class SomeCharm(CharmBase):
 import json
 import logging
 import os
-from dataclasses import dataclass, field
 import re
+from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
 import yaml
-from ops import Relation, RelationChangedEvent, SecretRemoveEvent, ModelError
+from ops import ModelError, Relation, RelationChangedEvent, SecretRemoveEvent
 from ops.charm import CharmBase, RelationEvent, SecretChangedEvent
 from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
 from ops.model import SecretNotFoundError
@@ -126,6 +126,7 @@ KUBERNETES_MANIFESTS_FIELD = "kubernetes_manifests"
 IS_SECRET_FIELD = "is_secret"
 MANIFESTS_SECRET_KEY = "manifests"
 
+
 def generate_secret_label(relation: Relation) -> str:
     """Generate a unique secret label based on the relation name and ID."""
     return f"manifest.{relation.name}.{relation.id}"
@@ -141,6 +142,7 @@ def parse_relation_id_from_secret_label(secret_label: str) -> Optional[int]:
         return int(match.group("relation_id"))
     except ValueError:
         return None
+
 
 @dataclass
 class KubernetesManifest:
@@ -201,9 +203,7 @@ class KubernetesManifestsProvider(Object):
         self._charm = charm
         self._relation_name = relation_name
 
-        self.framework.observe(
-            self._charm.on.secret_changed, self._on_secret_changed_event
-        )
+        self.framework.observe(self._charm.on.secret_changed, self._on_secret_changed_event)
         self.framework.observe(
             self._charm.on[self._relation_name].relation_changed, self._on_relation_changed
         )
@@ -418,7 +418,7 @@ class KubernetesManifestsRequirer(Object):
         if relation.name != self._relation_name:
             logging.info("Event triggered for some other relation.")
             return
-        
+
         # Ignore the event raised for secret that no longer exists
         # https://github.com/juju/juju/issues/20794
         try:
@@ -428,7 +428,6 @@ class KubernetesManifestsRequirer(Object):
             return
 
         event.remove_revision()
-
 
 
 class KubernetesManifestRequirerWrapper(Object):

--- a/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
+++ b/lib/charms/resource_dispatcher/v0/kubernetes_manifests.py
@@ -100,11 +100,14 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
+import re
 from typing import List, Optional, Union
 
 import yaml
-from ops.charm import CharmBase, RelationEvent
+from ops import Relation, RelationChangedEvent, SecretRemoveEvent
+from ops.charm import CharmBase, RelationEvent, SecretChangedEvent
 from ops.framework import BoundEvent, EventBase, EventSource, Object, ObjectEvents
+from ops.model import SecretNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -116,10 +119,27 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 KUBERNETES_MANIFESTS_FIELD = "kubernetes_manifests"
+IS_SECRET_FIELD = "is_secret"
+MANIFESTS_SECRET_KEY = "manifests"
 
+def generate_secret_label(relation: Relation) -> str:
+    """Generate a unique secret label based on the relation name and ID."""
+    return f"manifest.{relation.name}.{relation.id}"
+
+
+def parse_relation_id_from_secret_label(secret_label: str) -> Optional[int]:
+    """Parse the relation id from a secret label."""
+    pattern = r"^manifest\.(?P<relation_name>[^.]+)\.(?P<relation_id>\d+)$"
+    match = re.match(pattern, secret_label)
+    if not match:
+        return None
+    try:
+        return int(match.group("relation_id"))
+    except ValueError:
+        return None
 
 @dataclass
 class KubernetesManifest:
@@ -180,9 +200,11 @@ class KubernetesManifestsProvider(Object):
         self._relation_name = relation_name
 
         self.framework.observe(
+            self._charm.on.secret_changed, self._on_secret_changed_event
+        )
+        self.framework.observe(
             self._charm.on[self._relation_name].relation_changed, self._on_relation_changed
         )
-
         self.framework.observe(
             self._charm.on[self._relation_name].relation_broken, self._on_relation_broken
         )
@@ -217,18 +239,78 @@ class KubernetesManifestsProvider(Object):
             if other_app.name == other_app_to_skip:
                 # Skip this app because it is leaving a broken relation
                 continue
-            json_data = relation.data[other_app].get(KUBERNETES_MANIFESTS_FIELD, "[]")
+            is_secret = relation.data[other_app].get(IS_SECRET_FIELD, "false") == "true"
+            if is_secret:
+                secret_id = relation.data[other_app].get(KUBERNETES_MANIFESTS_FIELD, None)
+                if not secret_id:
+                    logger.error(
+                        f"Relation {relation.id} from app {other_app.name} indicates manifests are "
+                        f"in a secret, but no secret id was provided."
+                    )
+                    continue
+                secret = self._charm.model.get_secret(id=secret_id)
+                if not secret:
+                    logger.error(
+                        f"Relation {relation.id} from app {other_app.name} provided secret id "
+                        f"'{secret_id}' but no such secret exists."
+                    )
+                    continue
+                secret_content = secret.get_content(refresh=True)
+                json_data = secret_content.get(MANIFESTS_SECRET_KEY, "[]")
+            else:
+                json_data = relation.data[other_app].get(KUBERNETES_MANIFESTS_FIELD, "[]")
             manifests.extend(json.loads(json_data))
 
         return manifests
 
-    def _on_relation_changed(self, event):
+    def register_secrets_to_relation(self, relation: Relation):
+        if relation.data[relation.app].get(IS_SECRET_FIELD) != "true":
+            logger.info("Detected the other side is not sending secret, skipping secret registration.")
+            return
+
+        secret_uri = relation.data[relation.app].get(KUBERNETES_MANIFESTS_FIELD)
+        if not secret_uri:
+            return
+        secret_label = generate_secret_label(relation=relation)
+        try:
+            self.model.get_secret(label=secret_label)
+        except SecretNotFoundError:
+            self.model.get_secret(id=secret_uri, label=secret_label)
+
+    def _on_relation_changed(self, event: RelationChangedEvent):
         """Handler for relation-changed event for this relation."""
+        self.register_secrets_to_relation(event.relation)
         self.on.updated.emit(event.relation)
 
     def _on_relation_broken(self, event: BoundEvent):
         """Handler for relation-broken event for this relation."""
         self.on.updated.emit(event.relation)
+
+    def _on_secret_changed_event(self, event: SecretChangedEvent) -> None:
+        """Event handler for handling a new value of a secret."""
+        if not event.secret.label:
+            return
+
+        secret_label = event.secret.label
+        relation_id = parse_relation_id_from_secret_label(secret_label)
+        if relation_id is None:
+            logger.info(
+                f"Received secret {event.secret.label} but couldn't parse relation id, seems irrelevant."
+            )
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id)
+        if not relation:
+            logger.info(
+                f"Received secret {event.secret.label} but couldn't parse, seems irrelevant."
+            )
+            return
+
+        if relation.app == self._charm.app:
+            logger.info("Secret changed event ignored for Secret Owner")
+            return
+
+        self.on.updated.emit(relation)
 
 
 class KubernetesManifestsRequirer(Object):
@@ -274,6 +356,7 @@ class KubernetesManifestsRequirer(Object):
         self.framework.observe(
             self._charm.on[self._relation_name].relation_created, self._send_data
         )
+        self.framework.observe(self._charm.on.secret_remove, self._on_secret_remove)
 
         # apply user defined events
         if refresh_event:
@@ -286,6 +369,34 @@ class KubernetesManifestsRequirer(Object):
     def _send_data(self, event: EventBase):
         """Handles any event where we should send data to the relation."""
         self._requirer_wrapper.send_data(self._manifests_items)
+
+    def _on_secret_remove(self, event: SecretRemoveEvent):
+        """Handles secret-remove event, which gets triggered when secret revision is no longer being observed."""
+        if not event.secret.label:
+            return
+
+        relation_id = parse_relation_id_from_secret_label(event.secret.label)
+        if relation_id is None:
+            logger.info(
+                f"Received secret {event.secret.label} but couldn't parse relation id, seems irrelevant."
+            )
+            return
+
+        relation = self.model.get_relation(self._relation_name, relation_id)
+        if relation.name != self._relation_name:
+            logging.info("Event triggered for some other relation.")
+            return
+        
+        # Ignore the event raised for secret that no longer exists
+        # https://github.com/juju/juju/issues/20794
+        try:
+            event.secret.get_info()
+        except SecretNotFoundError:
+            logging.info("Secret removed for non-existent secret.")
+            return
+
+        event.remove_revision()
+
 
 
 class KubernetesManifestRequirerWrapper(Object):
@@ -315,10 +426,19 @@ class KubernetesManifestRequirerWrapper(Object):
 
         manifests = self._get_manifests_from_items(manifest_items)
         relations = self._charm.model.relations.get(self._relation_name)
+
         for relation in relations:
             relation_data = relation.data[self._charm.app]
             manifests_as_json = json.dumps(manifests)
-            relation_data.update({KUBERNETES_MANIFESTS_FIELD: manifests_as_json})
+            secret_content = {MANIFESTS_SECRET_KEY: manifests_as_json}
+            secret_label = generate_secret_label(relation=relation)
+            try:
+                secret = self._charm.model.get_secret(label=secret_label)
+                secret.set_content(secret_content)
+            except SecretNotFoundError:
+                secret = self._charm.app.add_secret(content=secret_content, label=secret_label)
+            secret.grant(relation=relation)
+            relation_data.update({KUBERNETES_MANIFESTS_FIELD: secret.id, IS_SECRET_FIELD: "true"})
 
 
 def get_name_of_breaking_app(relation_name: str) -> Optional[str]:

--- a/tests/integration/test_manifests.py
+++ b/tests/integration/test_manifests.py
@@ -86,12 +86,19 @@ def test_integrate_kubeflow_with_resource_dispatcher(
             # Check application data
             secrets_rel_data = list(
                 get_application_data(juju, RESOURCE_DISPATCHER_APP_NAME, "secrets").items()
-            )[0]
-            assert secrets_rel_data[1] == {"kubernetes_manifests": "[]"}
+            )[0][1]
+            secret_manifests_content = juju.show_secret(
+                identifier=secrets_rel_data["kubernetes_manifests"], reveal=True
+            ).content
+            assert secret_manifests_content == {"manifests": "[]"}
+
             poddefaults_rel_data = list(
                 get_application_data(juju, RESOURCE_DISPATCHER_APP_NAME, "pod-defaults").items()
-            )[0]
-            assert poddefaults_rel_data[1] == {"kubernetes_manifests": "[]"}
+            )[0][1]
+            poddefaults_manifest_content = juju.show_secret(
+                identifier=poddefaults_rel_data["kubernetes_manifests"], reveal=True
+            ).content
+            assert poddefaults_manifest_content == {"manifests": "[]"}
 
 
 def test_manifests_generation_with_opensearch(juju: jubilant.Juju, juju_vm: jubilant.Juju):
@@ -159,21 +166,24 @@ def test_manifests_generation_with_opensearch(juju: jubilant.Juju, juju_vm: jubi
     # Check application data
     secrets_rel_data = list(
         get_application_data(juju, RESOURCE_DISPATCHER_APP_NAME, "secrets").items()
-    )[0]
-    assert secrets_rel_data[1] != {}
+    )[0][1]
     poddefaults_rel_data = list(
         get_application_data(juju, RESOURCE_DISPATCHER_APP_NAME, "pod-defaults").items()
-    )[0]
-    assert poddefaults_rel_data[1] != {}
+    )[0][1]
 
-    assert "kubernetes_manifests" in secrets_rel_data[1]
-    secrets_k8s_manifests = json.loads(secrets_rel_data[1]["kubernetes_manifests"])
+    secret_manifests_content = juju.show_secret(
+        identifier=secrets_rel_data["kubernetes_manifests"], reveal=True
+    ).content
+    poddefaults_manifest_content = juju.show_secret(
+        identifier=poddefaults_rel_data["kubernetes_manifests"], reveal=True
+    ).content
+
+    secrets_k8s_manifests = json.loads(secret_manifests_content["manifests"])
     for secret_manifest in secrets_k8s_manifests:
         secret = validate_k8s_secret(secret_manifest)
         if secret.metadata.name == "opensearch-secret":
             assert secret.data["OPENSEARCH_INDEX"] == base64.b64encode(b"foobar").decode()
 
-    assert "kubernetes_manifests" in poddefaults_rel_data[1]
-    poddefaults_k8s_manifests = json.loads(poddefaults_rel_data[1]["kubernetes_manifests"])
+    poddefaults_k8s_manifests = json.loads(poddefaults_manifest_content["manifests"])
     for poddefault_manifest in poddefaults_k8s_manifests:
         validate_k8s_poddefault(poddefault_manifest)

--- a/tests/integration/test_manifests.py
+++ b/tests/integration/test_manifests.py
@@ -59,7 +59,6 @@ def test_integrate_kubeflow_with_resource_dispatcher(
         trust=True,
         channel=RESOURCE_DISPATCHER_CHANNEL,
         app=RESOURCE_DISPATCHER_APP_NAME,
-        revision=432,  # TODO: Remove pin once merged to latest/edge
     )
     juju.deploy(
         kubeflow_integrator,

--- a/tests/integration/test_manifests.py
+++ b/tests/integration/test_manifests.py
@@ -59,7 +59,7 @@ def test_integrate_kubeflow_with_resource_dispatcher(
         trust=True,
         channel=RESOURCE_DISPATCHER_CHANNEL,
         app=RESOURCE_DISPATCHER_APP_NAME,
-        revision=427,  # TODO: Remove pin once merged to latest/edge
+        revision=432,  # TODO: Remove pin once merged to latest/edge
     )
     juju.deploy(
         kubeflow_integrator,

--- a/tests/integration/test_manifests.py
+++ b/tests/integration/test_manifests.py
@@ -59,6 +59,7 @@ def test_integrate_kubeflow_with_resource_dispatcher(
         trust=True,
         channel=RESOURCE_DISPATCHER_CHANNEL,
         app=RESOURCE_DISPATCHER_APP_NAME,
+        revision=427,  # TODO: Remove pin once merged to latest/edge
     )
     juju.deploy(
         kubeflow_integrator,

--- a/tests/integration/test_spark.py
+++ b/tests/integration/test_spark.py
@@ -186,7 +186,7 @@ def test_deploy_resource_dispatcher_setup(juju: jubilant.Juju):
         RESOURCE_DISPATCHER,
         channel=RESOURCE_DISPATCHER_CHANNEL,
         trust=True,
-        revision=427,  # TODO: Remove pin once merged to latest/edge
+        revision=432,  # TODO: Remove pin once merged to latest/edge
     )
     juju.wait(
         lambda status: jubilant.all_active(status) and jubilant.all_agents_idle(status), delay=5

--- a/tests/integration/test_spark.py
+++ b/tests/integration/test_spark.py
@@ -246,7 +246,9 @@ def test_resource_dispatcher_relations(
             ).values()
         )
     )
-    res_in_relation_data = json.loads(relation_data["kubernetes_manifests"])
+    secret_uri = relation_data["kubernetes_manifests"]
+    secret_content = juju.show_secret(identifier=secret_uri, reveal=True).content
+    res_in_relation_data = json.loads(secret_content["manifests"])
     assert (
         len(
             [

--- a/tests/integration/test_spark.py
+++ b/tests/integration/test_spark.py
@@ -186,7 +186,6 @@ def test_deploy_resource_dispatcher_setup(juju: jubilant.Juju):
         RESOURCE_DISPATCHER,
         channel=RESOURCE_DISPATCHER_CHANNEL,
         trust=True,
-        revision=432,  # TODO: Remove pin once merged to latest/edge
     )
     juju.wait(
         lambda status: jubilant.all_active(status) and jubilant.all_agents_idle(status), delay=5

--- a/tests/integration/test_spark.py
+++ b/tests/integration/test_spark.py
@@ -186,6 +186,7 @@ def test_deploy_resource_dispatcher_setup(juju: jubilant.Juju):
         RESOURCE_DISPATCHER,
         channel=RESOURCE_DISPATCHER_CHANNEL,
         trust=True,
+        revision=427,  # TODO: Remove pin once merged to latest/edge
     )
     juju.wait(
         lambda status: jubilant.all_active(status) and jubilant.all_agents_idle(status), delay=5

--- a/tests/unit/test_kafka.py
+++ b/tests/unit/test_kafka.py
@@ -106,12 +106,20 @@ def test_charm_generate_secret_manifests_when_integrated(
 
     # Then:
     assert state_out.app_status == ActiveStatus()
+
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
+
     generated_secret = kubernetes_manifests[0]
+    assert generated_secret is not None
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"
 
@@ -179,12 +187,20 @@ def test_charm_generate_no_namespace_secret_manifests_when_integrated(
 
     # Then:
     assert state_out.app_status == ActiveStatus()
+
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
+
     generated_secret = kubernetes_manifests[0]
+    assert generated_secret is not None
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"
 
@@ -192,4 +208,5 @@ def test_charm_generate_no_namespace_secret_manifests_when_integrated(
     assert (
         generated_secret["data"]["KAFKA_PASSWORD"] == base64.b64encode(b"user-password").decode()
     )
+
     assert "namespace" not in generated_secret["metadata"]

--- a/tests/unit/test_mongodb.py
+++ b/tests/unit/test_mongodb.py
@@ -107,10 +107,15 @@ def test_charm_generate_secret_manifests_when_integrated(
     # Then:
     assert state_out.app_status == ActiveStatus()
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"
@@ -180,10 +185,15 @@ def test_charm_generate_no_namespace_secret_manifests_when_integrated(
     # Then:
     assert state_out.app_status == ActiveStatus()
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"

--- a/tests/unit/test_mysql.py
+++ b/tests/unit/test_mysql.py
@@ -107,10 +107,15 @@ def test_charm_generate_secret_manifests_when_integrated(
     # Then:
     assert state_out.app_status == ActiveStatus()
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"
@@ -180,10 +185,15 @@ def test_charm_generate_no_namespace_secret_manifests_when_integrated(
     # Then:
     assert state_out.app_status == ActiveStatus()
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"

--- a/tests/unit/test_opensearch.py
+++ b/tests/unit/test_opensearch.py
@@ -106,11 +106,18 @@ def test_charm_generate_secret_manifests_when_integrated(
 
     # Then:
     assert state_out.app_status == ActiveStatus()
+
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
+
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"
@@ -182,11 +189,18 @@ def test_charm_generate_no_namespace_secret_manifests_when_integrated(
 
     # Then:
     assert state_out.app_status == ActiveStatus()
+
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
+
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"

--- a/tests/unit/test_postgresql.py
+++ b/tests/unit/test_postgresql.py
@@ -107,10 +107,15 @@ def test_charm_generate_secret_manifests_when_integrated(
     # Then:
     assert state_out.app_status == ActiveStatus()
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"
@@ -183,10 +188,15 @@ def test_charm_generate_no_namespace_secret_manifests_when_integrated(
     # Then:
     assert state_out.app_status == ActiveStatus()
     # Make sure the manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_manifests_relation.id).local_app_data[
-        "kubernetes_manifests"
+    app_data = state_out.get_relation(secrets_manifests_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"

--- a/tests/unit/test_spark.py
+++ b/tests/unit/test_spark.py
@@ -152,51 +152,76 @@ def test_charm_active_and_manifests_generated_when_serviceaccount_configured(
     state_out = ctx.run(ctx.on.relation_changed(secrets_relation), state_in)
     assert state_out.app_status == ActiveStatus()
 
-    # Make sure the secret manifest is generated
-    kubernetes_manifests = state_out.get_relation(secrets_relation.id).local_app_data[
-        "kubernetes_manifests"
+    # Make sure the manifest is generated
+    app_data = state_out.get_relation(secrets_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     generated_secret = kubernetes_manifests[0]
     assert generated_secret["apiVersion"] == "v1"
     assert generated_secret["kind"] == "Secret"
     assert generated_secret["metadata"]["name"] == "integrator-hub-conf-spark"
 
-    # Make sure the service-accounts manifest is generated
-    kubernetes_manifests = state_out.get_relation(service_accounts_relation.id).local_app_data[
-        "kubernetes_manifests"
+    # Make sure the manifest is generated
+    app_data = state_out.get_relation(service_accounts_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     service_account = kubernetes_manifests[0]
     assert service_account["apiVersion"] == "v1"
     assert service_account["kind"] == "ServiceAccount"
     assert service_account["metadata"]["name"] == "spark"
 
-    # Make sure the roles manifest is generated
-    kubernetes_manifests = state_out.get_relation(roles_relation.id).local_app_data[
-        "kubernetes_manifests"
+    # Make sure the manifest is generated
+    app_data = state_out.get_relation(roles_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     role = kubernetes_manifests[0]
     assert role["apiVersion"] == "rbac.authorization.k8s.io/v1"
     assert role["kind"] == "Role"
     assert role["metadata"]["name"] == "spark-role"
 
-    # Make sure the role-bindings manifest is generated
-    kubernetes_manifests = state_out.get_relation(role_bindings_relation.id).local_app_data[
-        "kubernetes_manifests"
+    # Make sure the manifest is generated
+    app_data = state_out.get_relation(role_bindings_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     rolebinding = kubernetes_manifests[0]
     assert rolebinding["apiVersion"] == "rbac.authorization.k8s.io/v1"
     assert rolebinding["kind"] == "RoleBinding"
     assert rolebinding["metadata"]["name"] == "spark-role-binding"
 
-    # Make sure the pod-defaults manifest is generated
-    kubernetes_manifests = state_out.get_relation(pod_defaults_relation.id).local_app_data[
-        "kubernetes_manifests"
+    # Make sure the manifest is generated
+    app_data = state_out.get_relation(pod_defaults_relation.id).local_app_data
+    assert app_data["is_secret"] == "true"
+    manifests_secret_id = app_data["kubernetes_manifests"]
+    manifest_secret = [secret for secret in state_out.secrets if secret.id == manifests_secret_id][
+        0
     ]
-    kubernetes_manifests = json.loads(kubernetes_manifests)
+    secret_content = manifest_secret.latest_content
+    assert secret_content is not None
+    kubernetes_manifests = json.loads(secret_content["manifests"])
     assert len(kubernetes_manifests) == 2
 
     pipeline_poddefault = [


### PR DESCRIPTION
As the title says, the charm is updated to use `kubernetes_manifests` lib v0.2.

In doing so, the tests are updated so that the correct behavior is tested across the code.