### PR TITLE
[PRA-7] Add pod annotation and args for spark executors

### DIFF
--- a/src/managers/spark.py
+++ b/src/managers/spark.py
@@ -157,10 +157,23 @@ class SparkManager(ManagerStatusProtocol, WithLogging):
         spark_pipeline_poddefault = generate_poddefault_manifest(
             self.manifest_manager.poddefault_k8s_template,
             self.state.profile_config.profile,
-            creds={"SPARK_SERVICE_ACCOUNT": service_account},
+            creds={
+                "SPARK_SERVICE_ACCOUNT": service_account,
+                "PYSPARK_SUBMIT_ARGS": (
+                    f" --conf spark.driver.port={SPARK_DRIVER_PORT}"
+                    f" --conf spark.blockManager.port={SPARK_BLOCK_MANAGER_PORT}"
+                    f" --conf spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeInboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}"
+                    f" --conf spark.kubernetes.executor.annotation.traffic.sidecar.istio.io/excludeOutboundPorts={SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}"
+                    " pyspark-shell"
+                ),
+            },
             database_name=SPARK,
             poddefault_name=SPARK_PIPELINE_PODDEFAULT_NAME,
             poddefault_description=SPARK_PIPELINE_PODDEFAULT_DESC,
+            annotations={
+                "traffic.sidecar.istio.io/excludeInboundPorts": f"{SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
+                "traffic.sidecar.istio.io/excludeOutboundPorts": f"{SPARK_DRIVER_PORT},{SPARK_BLOCK_MANAGER_PORT}",
+            },
             fieldrefs={"SPARK_NAMESPACE": "metadata.namespace"},
             selector_name=SPARK_PIPELINE_PODDEFAULT_SELECTOR_LABEL,
         )


### PR DESCRIPTION
I noticed that occasionally the Spark Jobs are failing with the following exception:

```
org.apache.spark.shuffle.FetchFailedException
	at org.apache.spark.errors.SparkCoreErrors$.fetchFailedError(SparkCoreErrors.scala:437)
	at org.apache.spark.storage.ShuffleBlockFetcherIterator.throwFetchFailedException(ShuffleBlockFetcherIterator.scala:1239)
	at org.apache.spark.storage.ShuffleBlockFetcherIterator.next(ShuffleBlockFetcherIterator.scala:971)
	at org.apache.spark.storage.ShuffleBlockFetcherIterator.next(ShuffleBlockFetcherIterator.scala:86)
	at org.apache.spark.util.CompletionIterator.next(CompletionIterator.scala:29)
	at scala.collection.Iterator$$anon$11.nextCur(Iterator.scala:486)
	at scala.collection.Iterator$$anon$11.hasNext(Iterator.scala:492)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at org.apache.spark.util.CompletionIterator.hasNext(CompletionIterator.scala:31)
	at org.apache.spark.InterruptibleIterator.hasNext(InterruptibleIterator.scala:37)
	at scala.collection.Iterator$$anon$10.hasNext(Iterator.scala:460)
	at scala.collection.Iterator.foreach(Iterator.scala:943)
	at scala.collection.Iterator.foreach$(Iterator.scala:943)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1431)
	at org.apache.spark.api.python.PythonRDD$.writeIteratorToStream(PythonRDD.scala:322)
	at org.apache.spark.api.python.PythonRunner$$anon$2.writeIteratorToStream(PythonRunner.scala:751)
	at org.apache.spark.api.python.BasePythonRunner$WriterThread.$anonfun$run$1(PythonRunner.scala:451)
	at org.apache.spark.util.Utils$.logUncaughtExceptions(Utils.scala:1927)
	at org.apache.spark.api.python.BasePythonRunner$WriterThread.run(PythonRunner.scala:282)
```

This happens in case of some Spark job runs in the pipeline. After a detailed investigation, and also remembering the issue reported by Enrico to last week -- indeed the Spark Executors are missing the necessary annotations for communication between the block manager and driver.

The cleanest way I found to add these were the usage of `PYSPARK_SUBMIT_ARGS` environment variable, such that the user need not add these configurations in the notebook themselves.