### PR TITLE
chore: allow publishing to latest/edge on main

### DIFF
--- a/.github/automatic_backport_tracks.yaml
+++ b/.github/automatic_backport_tracks.yaml
@@ -1,0 +1,2 @@
+automatic_backport_tracks:
+  - track/1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,11 +16,51 @@ on:
       artifact-prefix:
         description: build_charm.yaml `artifact-prefix` output
         value: ${{ jobs.build.outputs.artifact-prefix }}
+      charm-paths:
+        description: paths for all charms in this repo
+        value: ${{ jobs.get-charm-paths-track.outputs.charm-paths }}
+      track:
+        description: Charmhub track determined from branch name
+        value: ${{ jobs.get-charm-paths-track.outputs.track }}
 
 jobs:
+  get-charm-paths-track:
+    name: Get charm paths and track
+    runs-on: ubuntu-latest
+    outputs:
+      charm-paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
+      track: ${{ steps.determine-track.outputs.track }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Get paths for all charms in this repo
+        id: get-charm-paths
+        uses: canonical/kubeflow-ci/actions/get-charm-paths@main
+      - name: Determine track
+        id: determine-track
+        shell: python
+        run: |
+          import os
+
+          if "${{ github.event_name }}" == "pull_request":
+              ref = "${{ github.base_ref }}"
+          else:
+              ref = "${{ github.ref_name }}"
+
+          if ref.startswith("track/"):
+              track = ref.removeprefix("track/")
+          else:
+              track = "latest"
+
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(f"track={track}\n")
+
+          print(f"Track: {track}")
+
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v49.0.1
 
   lib-check:
     name: Check libraries
@@ -60,13 +100,17 @@ jobs:
   build:
     strategy:
       matrix:
-        path:
-          - .
-    name: Build charm | ${{ matrix.path }}
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v32.1.0
+        charm: ${{ fromJSON(needs.get-charm-paths-track.outputs.charm-paths) }}
+    name: Build charm | ${{ matrix.charm }}
+    needs:
+      - get-charm-paths-track
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v49.0.1
     with:
-      cache: false
-      path-to-charm-directory: ${{ matrix.path }}
+      cache: true
+      path-to-charm-directory: ${{ matrix.charm }}
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version (for private repositories)
+      contents: read
 
   integration-test:
     name: Integration test charm

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,9 @@ jobs:
 
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v49.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v49.0.1
+    permissions:
+      contents: read
 
   lib-check:
     name: Check libraries

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ on:
 jobs:
   get-charm-paths-track:
     name: Get charm paths and track
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     outputs:
       charm-paths: ${{ steps.get-charm-paths.outputs.charm-paths }}
       track: ${{ steps.determine-track.outputs.track }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,7 +60,7 @@ jobs:
 
   lint:
     name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint_workflows.yaml@v49.0.1
+    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v32.1.0
     permissions:
       contents: read
 

--- a/.github/workflows/on_pull_request_closed.yaml
+++ b/.github/workflows/on_pull_request_closed.yaml
@@ -1,0 +1,23 @@
+name: On Pull Request Closed
+
+# When a pull request is pushed on the main branch, automatically
+# create backport PRs according to the labels on the pull request.
+# If there are conflicts, create a PR but leave it as draft.
+
+on:
+  pull_request_target:
+    types: [closed]
+    branches:
+    - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+
+  backport:
+    name: Backport pull request
+    if: github.event.pull_request.merged
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/backport-pr.yaml@main
+    secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,7 +53,7 @@ jobs:
           echo "${{ needs.release.outputs.charm-revisions}}" | yq ".[]" > revisions
           while read LINE; do
             echo "Promoting $LINE to 1/edge"
-            charmcraft release data-kubeflow-integrator --channel=1/edge --revision $LINE
+            charmcraft release data-kubeflow-integrator --channel=1/edge --revision=$LINE
           done < revisions
     permissions:
       actions: read  # Needed for GitHub API call to get workflow version

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,7 +30,7 @@ jobs:
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
       path-to-charm-directory: ${{ matrix.charm }}
     secrets:
-      charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
       actions: read
       contents: write  # Needed to create git tags

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,34 +27,3 @@ jobs:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
       contents: write  # Needed to create git tags
-
-  promote:
-    name: Parse release output
-    runs-on: ubuntu-24.04
-    needs:
-      - release
-    timeout-minutes: 5
-    steps:
-      - name: Install tools
-        run: |
-          sudo snap install yq
-
-          sudo snap install charmcraft --classic
-          charmcraft version
-
-      - name: Login to Charmhub
-        uses: canonical/charming-actions/charmcraft-login@2.6.0
-        with:
-          credentials: ${{ secrets.CHARMHUB_TOKEN }}
-
-      - name: Revision promotion
-        id: parser
-        run: |
-          echo "${{ needs.release.outputs.charm-revisions}}" | yq ".[]" > revisions
-          while read -r LINE; do
-            echo "Promoting $LINE to 1/edge"
-            charmcraft release data-kubeflow-integrator --channel=1/edge --revision="$LINE"
-          done < revisions
-    permissions:
-      actions: read  # Needed for GitHub API call to get workflow version
-      contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+      - track/1
 
 jobs:
   ci-tests:
@@ -13,17 +14,24 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
     permissions:
-      contents: write  # Needed for Allure Report beta
+      actions: read
+      contents: read
 
   release:
-    name: Release charm
+    strategy:
+      matrix:
+        charm: ${{ fromJSON(needs.ci-tests.outputs.charm-paths) }}
+    name: Release charm | ${{ matrix.charm }}
     needs:
       - ci-tests
-    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
+    uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v49.0.1
     with:
-      track: "latest"
+      track: ${{ needs.ci-tests.outputs.track }}
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
+      path-to-charm-directory: ${{ matrix.charm }}
     secrets:
-      charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
+      charmhub-token: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
     permissions:
+      actions: read
       contents: write  # Needed to create git tags
+  

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,9 +21,40 @@ jobs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:
-      track: "1"
+      track: "latest"
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:
       contents: write  # Needed to create git tags
+
+  promote:
+    name: Parse release output
+    runs-on: ubuntu-24.04
+    needs:
+      - release
+    timeout-minutes: 5
+    steps:
+      - name: Install tools
+        run: |
+          sudo snap install yq
+
+          sudo snap install charmcraft --classic
+          charmcraft version
+
+      - name: Login to Charmhub
+        uses: canonical/charming-actions/charmcraft-login@2.6.0
+        with:
+          credentials: ${{ secrets.CHARMHUB_TOKEN }}
+
+      - name: Revision promotion
+        id: parser
+        run: |
+          echo "${{ needs.release.outputs.charm-revisions}}" | yq ".[]" > revisions
+          while read LINE; do
+            echo "Promoting $LINE to 1/edge"
+            charmcraft release data-kubeflow-integrator --channel=1/edge --revision $LINE
+          done < revisions
+    permissions:
+      actions: read  # Needed for GitHub API call to get workflow version
+      contents: write  # Needed to edit GitHub releases

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,9 +51,9 @@ jobs:
         id: parser
         run: |
           echo "${{ needs.release.outputs.charm-revisions}}" | yq ".[]" > revisions
-          while read LINE; do
+          while read -r LINE; do
             echo "Promoting $LINE to 1/edge"
-            charmcraft release data-kubeflow-integrator --channel=1/edge --revision=$LINE
+            charmcraft release data-kubeflow-integrator --channel=1/edge --revision="$LINE"
           done < revisions
     permissions:
       actions: read  # Needed for GitHub API call to get workflow version


### PR DESCRIPTION
This should allow to publish to latest/edge to be consistent with the rest of the Kubeflow charms. 