### PR TITLE
fix: Give contents: write permission to release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     secrets: inherit
     permissions:
       actions: read
-      contents: write
+      contents: write  # Needed for the Allure report
 
   release:
     strategy:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
     secrets: inherit
     permissions:
       actions: read
-      contents: read
+      contents: write
 
   release:
     strategy:
@@ -34,4 +34,3 @@ jobs:
     permissions:
       actions: read
       contents: write  # Needed to create git tags
-  


### PR DESCRIPTION
This PR gives `contents: write` permissions to the `release.yaml` workflow to fix [failing CI](https://github.com/canonical/data-kubeflow-integrator/actions/workflows/release.yaml)